### PR TITLE
profile and property for fat-jar. Fixes #21.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <cmake.generate.extra></cmake.generate.extra>
     <cmake.generate.skip>false</cmake.generate.skip>
     <javah.skip>false</javah.skip>
+    <skip.fat.jar>true</skip.fat.jar>
     <maven.assembly.id>${os.detected.name}-${os.detected.arch}-${os.detected.bitness}</maven.assembly.id>
     <!-- TODO: remove "os.detected.bitness"; already defined os-maven-plugin 1.6.3+ -->
     <os.detected.bitness>${sun.arch.data.model}</os.detected.bitness>
@@ -228,6 +229,20 @@
               </descriptors>
             </configuration>
           </execution>
+
+          <execution>
+            <id>fat-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <skipAssembly>${skip.fat.jar}</skipAssembly>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -324,6 +339,13 @@
          </plugin>
        </plugins>
      </build>
+    </profile>
+
+    <profile>
+      <id>fat-jar</id>
+      <properties>
+        <skip.fat.jar>false</skip.fat.jar>
+      </properties>
     </profile>
 
     <!-- cmake linux 32-bit profile -->

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <cmake.generate.extra></cmake.generate.extra>
     <cmake.generate.skip>false</cmake.generate.skip>
     <javah.skip>false</javah.skip>
-    <skip.jar.with.dependencies>true</skip.jar.with.dependencies>
+    <jar.dependencies.skip>true</jar.dependencies.skip>
     <maven.assembly.id>${os.detected.name}-${os.detected.arch}-${os.detected.bitness}</maven.assembly.id>
     <!-- TODO: remove "os.detected.bitness"; already defined os-maven-plugin 1.6.3+ -->
     <os.detected.bitness>${sun.arch.data.model}</os.detected.bitness>
@@ -237,7 +237,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <skipAssembly>${skip.jar.with.dependencies}</skipAssembly>
+              <skipAssembly>${jar.dependencies.skip}</skipAssembly>
               <descriptorRefs>
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>
@@ -344,7 +344,7 @@
     <profile>
       <id>jar-with-dependencies</id>
       <properties>
-        <skip.jar.with.dependencies>false</skip.jar.with.dependencies>
+        <jar.dependencies.skip>false</jar.dependencies.skip>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <cmake.generate.extra></cmake.generate.extra>
     <cmake.generate.skip>false</cmake.generate.skip>
     <javah.skip>false</javah.skip>
-    <skip.fat.jar>true</skip.fat.jar>
+    <skip.jar.with.dependencies>true</skip.jar.with.dependencies>
     <maven.assembly.id>${os.detected.name}-${os.detected.arch}-${os.detected.bitness}</maven.assembly.id>
     <!-- TODO: remove "os.detected.bitness"; already defined os-maven-plugin 1.6.3+ -->
     <os.detected.bitness>${sun.arch.data.model}</os.detected.bitness>
@@ -237,7 +237,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <skipAssembly>${skip.fat.jar}</skipAssembly>
+              <skipAssembly>${skip.jar.with.dependencies}</skipAssembly>
               <descriptorRefs>
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>
@@ -342,9 +342,9 @@
     </profile>
 
     <profile>
-      <id>fat-jar</id>
+      <id>jar-with-dependencies</id>
       <properties>
-        <skip.fat.jar>false</skip.fat.jar>
+        <skip.jar.with.dependencies>false</skip.jar.with.dependencies>
       </properties>
     </profile>
 


### PR DESCRIPTION
Adds a property and a profile. Both will work. E.g.

  * `mvn clean install -Ppackage,jar-with-dependencies`
  * `mvn clean install -Ppackage -Djar.dependencies.skip=false`

https://github.com/java-native/jssc/issues/21