### PR TITLE
Fix memory leak in getFlowControlMode()

### DIFF
--- a/src/cpp/_nix_based/jssc.cpp
+++ b/src/cpp/_nix_based/jssc.cpp
@@ -621,6 +621,7 @@ JNIEXPORT jint JNICALL Java_jssc_SerialNativeInterface_getFlowControlMode
             returnValue |= FLOWCONTROL_XONXOFF_OUT;
         }
     }
+    delete settings;
     return returnValue;
 }
 


### PR DESCRIPTION
This pull request fixes a memory leak in C++ code. The leak was triggered on every call to SerialNativeInterface::getFlowControlMode() from Java code.

I have not updated the precompiled native libraries as I don't have the right tooling to make builds for all platforms. Hoping that somebody else can take care of that.