### PR TITLE
javadoc-generation-fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
 
   <properties>
     <java.version>1.6</java.version>
-    <!-- default: empty for compatiblity with Java 8. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- custom directories and file paths a-z -->
@@ -42,8 +41,7 @@
     <plugin.osmaven.version>1.6.2</plugin.osmaven.version>
     <plugin.signature.version>1.1</plugin.signature.version>
     <plugin.surfire.version>3.0.0-M3</plugin.surfire.version>
-    <!-- keep below 3.1.0 because 3.1.0 fails on java 8. -->
-    <plugin.javadoc.version>3.0.1</plugin.javadoc.version>
+    <plugin.javadoc.version>3.1.1</plugin.javadoc.version>
     <plugin.source.version>3.0.1</plugin.source.version>
     <plugin.compiler.version>3.8.0</plugin.compiler.version>
   </properties>
@@ -217,7 +215,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <doclint>none</doclint>
           <!-- workaround for https://bugs.openjdk.java.net/browse/JDK-8212233 -->
           <javaApiLinks>
             <property>

--- a/src/java/jssc/SerialNativeInterface.java
+++ b/src/java/jssc/SerialNativeInterface.java
@@ -256,8 +256,8 @@ public class SerialNativeInterface {
      * @param handle handle of opened port
      *
      * @return Method returns the array that contains info about bytes count in buffers:
-     * <br><b>element 0</b> - input buffer</br>
-     * <br><b>element 1</b> - output buffer</br>
+     * <br><b>element 0</b> - input buffer
+     * <br><b>element 1</b> - output buffer
      *
      * @since 0.8
      */
@@ -299,10 +299,10 @@ public class SerialNativeInterface {
      * @param handle handle of opened port
      *
      * @return Method returns the array containing information about lines in following order:
-     * <br><b>element 0</b> - <b>CTS</b> line state</br>
-     * <br><b>element 1</b> - <b>DSR</b> line state</br>
-     * <br><b>element 2</b> - <b>RING</b> line state</br>
-     * <br><b>element 3</b> - <b>RLSD</b> line state</br>
+     * <br><b>element 0</b> - <b>CTS</b> line state
+     * <br><b>element 1</b> - <b>DSR</b> line state
+     * <br><b>element 2</b> - <b>RING</b> line state
+     * <br><b>element 3</b> - <b>RLSD</b> line state
      */
     public native int[] getLinesStatus(long handle);
 

--- a/src/java/jssc/SerialPort.java
+++ b/src/java/jssc/SerialPort.java
@@ -884,10 +884,10 @@ public class SerialPort {
      * Getting lines status. Lines status is sent as 0 – OFF and 1 - ON
      *
      * @return Method returns the array containing information about lines in following order:
-     * <br><b>element 0</b> - <b>CTS</b> line state</br>
-     * <br><b>element 1</b> - <b>DSR</b> line state</br>
-     * <br><b>element 2</b> - <b>RING</b> line state</br>
-     * <br><b>element 3</b> - <b>RLSD</b> line state</br>
+     * <br><b>element 0</b> - <b>CTS</b> line state
+     * <br><b>element 1</b> - <b>DSR</b> line state
+     * <br><b>element 2</b> - <b>RING</b> line state
+     * <br><b>element 3</b> - <b>RLSD</b> line state
      *
      * @throws SerialPortException
      */

--- a/src/java/jssc/SerialPortEvent.java
+++ b/src/java/jssc/SerialPortEvent.java
@@ -66,17 +66,17 @@ public class SerialPortEvent {
 
     /**
      * Getting event value
-     * <br></br>
-     * <br><u><b>Event values depending on their types:</b></u></br>
-     * <br><b>RXCHAR</b> - bytes count in input buffer</br>
-     * <br><b>RXFLAG</b> - bytes count in input buffer (Not supported in Linux)</br>
-     * <br><b>TXEMPTY</b> - bytes count in output buffer</br>
-     * <br><b>CTS</b> - state of CTS line (0 - OFF, 1 - ON)</br>
-     * <br><b>DSR</b> - state of DSR line (0 - OFF, 1 - ON)</br>
-     * <br><b>RLSD</b> - state of RLSD line (0 - OFF, 1 - ON)</br>
-     * <br><b>BREAK</b> - 0</br>
-     * <br><b>RING</b> - state of RING line (0 - OFF, 1 - ON)</br>
-     * <br><b>ERR</b> - mask of errors</br>
+     * <br>
+     * <br><u><b>Event values depending on their types:</b></u>
+     * <br><b>RXCHAR</b> - bytes count in input buffer
+     * <br><b>RXFLAG</b> - bytes count in input buffer (Not supported in Linux)
+     * <br><b>TXEMPTY</b> - bytes count in output buffer
+     * <br><b>CTS</b> - state of CTS line (0 - OFF, 1 - ON)
+     * <br><b>DSR</b> - state of DSR line (0 - OFF, 1 - ON)
+     * <br><b>RLSD</b> - state of RLSD line (0 - OFF, 1 - ON)
+     * <br><b>BREAK</b> - 0
+     * <br><b>RING</b> - state of RING line (0 - OFF, 1 - ON)
+     * <br><b>ERR</b> - mask of errors
      */
     public int getEventValue() {
         return eventValue;


### PR DESCRIPTION
This pull request addresses javadoc linter issues that are curently being worked around by suppressing doclint entirely.