### PR TITLE
Include module-info.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <plugin.animalsniffer.version>1.17</plugin.animalsniffer.version>
     <plugin.antrun.version>1.8</plugin.antrun.version>
     <plugin.assembly.version>3.1.1</plugin.assembly.version>
+    <plugin.enforcer.version>3.0.0-M3</plugin.enforcer.version>
     <plugin.jar.version>3.1.1</plugin.jar.version>
     <plugin.nar.version>3.6.0</plugin.nar.version>
     <plugin.osmaven.version>1.6.2</plugin.osmaven.version>
@@ -134,6 +135,33 @@
     </pluginManagement>
 
     <plugins>
+      <!-- Warn about not fully supported java version -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${plugin.enforcer.version}</version>
+        <executions>
+          <execution>
+            <id>recommended-jdk</id>
+            <goals><goal>enforce</goal></goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[9,)</version>
+                  <level>WARN</level>
+                  <message>Current JDK does not support Java Platform Module System. Resulting jar cannot be used as Java module.</message>
+                </requireJavaVersion>
+                <requireJavaVersion>
+                  <version>(,12)</version>
+                  <level>WARN</level>
+                  <message>Current JDK does not support target version 6. Minimal JRE to use the library on is ${target.java.version}.</message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- create header file jdk<=8 -->
       <plugin>
         <groupId>com.github.maven-nar</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   </scm>
 
   <properties>
-    <java.version>1.6</java.version>
+    <target.java.version>6</target.java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- custom directories and file paths a-z -->
@@ -204,8 +204,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <source>${target.java.version}</source>
+          <target>${target.java.version}</target>
           <compilerArgument>-Xlint:all</compilerArgument>
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
@@ -302,15 +302,19 @@
   </build>
 
   <profiles>
-    <!-- create header file jdk9+ -->
+
+    <!-- Standard profile for compiling classes with widest target range.
+         The resulting jar just works on jre6+ as well as a part of JPMS.
+         Resulting artifact is deployable to Maven Central -->
     <profile>
-      <id>java-9</id>
+      <id>jdk9+</id>
       <activation>
         <jdk>[9,)</jdk>
       </activation>
       <properties>
         <javah.skip>true</javah.skip>
-        <maven.compiler.release>6</maven.compiler.release>
+        <maven.compiler.release>${target.java.version}</maven.compiler.release>
+        <plugin.animalsniffer.version>1.20</plugin.animalsniffer.version>
       </properties>
       <build>
         <plugins>
@@ -322,9 +326,39 @@
                 <arg>${cmake.generated.directory}</arg>
               </compilerArgs>
             </configuration>
+            <executions>
+              <!-- compile everything to ensure module-info contains right entries -->
+              <execution>
+                <id>default-compile</id>
+                <configuration>
+                  <release>9</release>
+                  <compileSourceRoots>
+                    <sourceRoot>src/main/java</sourceRoot>
+                    <sourceRoot>src/main/module-info</sourceRoot>
+                  </compileSourceRoots>
+                </configuration>
+              </execution>
+              <!-- recompile everything for target VM except the module-info.java -->
+              <execution>
+                <id>minimal-target-jre-recompile</id>
+                <goals><goal>compile</goal></goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <!-- Convenience profile for users of JDKs past 11 who may want to
+         build the library ignoring no longer supported target version 6 -->
+    <profile>
+      <id>jdk12+</id>
+      <activation>
+        <jdk>[12,)</jdk>
+      </activation>
+      <properties>
+        <target.java.version>7</target.java.version>
+      </properties>
     </profile>
 
     <!-- collect existing native libraries for a distribution; skips native compilation -->

--- a/src/main/module-info/module-info.java
+++ b/src/main/module-info/module-info.java
@@ -1,0 +1,4 @@
+open module jssc {
+    requires org.scijava.nativelib;
+    exports jssc;
+}


### PR DESCRIPTION
This adds very simple module-info to the project. For public release the artifact should be build with JDK11. This ensures that module-info is added, while the classes are still kept at bytecode version 50.0 (Java 6), so this change does not affect users in any way. Building with JDK7 or 8 will result in jar missing module-info, but otherwise functional. Building with JDK12+ is now possible, but the resulting bytecode version of jssc classes is bumped to 51 (Java 7), so it would cut backwards compatibility a bit.

#79 