### PR TITLE
Add Gradle (KTS and Groovy) Artifact link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ A small, single Java library for working with serial ports across various system
     <version>2.9.2</version>
 </dependency>
 ```
+* or Gradle (KTS)
+```
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation("io.github.java-native:jssc:2.9.2")
+}
+```
+* or Gradle (Groovy)
+```
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation 'io.github.java-native:jssc:2.9.2'
+}
+```
 * [API code examples](../../wiki/examples)
 
 ### Support


### PR DESCRIPTION
Tested the KTS version in a separate project and also added the Groovy version of the same effect.

This allowed me to easily use the Serial Port in my Kotlin project as the following example:
```Kotlin
val byteArrays: MutableList<UByteArray> = mutableListOf(
    ubyteArrayOf(1u, 4u, 34u, 28u),
    ubyteArrayOf(3u, 7u, 34u, 28u),
)
val port = SerialPort("COM10")
port.openPort()
port.setParams(115200, 8, 2, 0)
for (array in byteArrays) {
    port.writeBytes(array.asByteArray())
    Thread.sleep(20)
}
port.closePort()
```
It's relatively easy to translate from a Maven artefact to a Gradle one, but I thought it'd be nice to be able to copy paste it from the ReadMe anyway.
