### PR TITLE
WIP: Pass the bytes along with the SerialPortEventa

### DIFF
--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1110,7 +1110,11 @@ public class SerialPort {
                 int[][] eventArray = waitEvents();
                 for(int i = 0; i < eventArray.length; i++){
                     if(eventArray[i][0] > 0 && !threadTerminated){
-                        eventListener.serialEvent(new SerialPortEvent(portName, eventArray[i][0], eventArray[i][1]));
+                        try {
+                            eventListener.serialEvent(new SerialPortEvent(readBytes(), portName, eventArray[i][0], eventArray[i][1]));
+                        } catch (SerialPortException ignored) {
+                            //TODO: How should this be handled?
+                        }
                         //FIXME
                         /*if(methodErrorOccurred != null){
                             try {
@@ -1297,7 +1301,11 @@ public class SerialPort {
                                 break;
                         }
                         if(sendEvent){
-                            eventListener.serialEvent(new SerialPortEvent(portName, eventType, eventValue));
+                            try {
+                                eventListener.serialEvent(new SerialPortEvent(readBytes(), portName, eventType, eventValue));
+                            } catch (SerialPortException ignored) {
+                                //TODO: How should this be handled?
+                            }
                         }
                     }
                 }

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -151,7 +151,7 @@ public class SerialPort {
      */
     public boolean openPort() throws SerialPortException {
         if(portOpened){
-            throw new SerialPortException(portName, "openPort()", SerialPortException.TYPE_PORT_ALREADY_OPENED);
+            throw new SerialPortException(this, "openPort()", SerialPortException.TYPE_PORT_ALREADY_OPENED);
         }
         if(portName != null){
             boolean useTIOCEXCL = (System.getProperty(SerialNativeInterface.PROPERTY_JSSC_NO_TIOCEXCL) == null &&
@@ -159,19 +159,19 @@ public class SerialPort {
             portHandle = serialInterface.openPort(portName, useTIOCEXCL);//since 2.3.0 -> (if JSSC_NO_TIOCEXCL defined, exclusive lock for serial port will be disabled)
         }
         else {
-            throw new SerialPortException(portName, "openPort()", SerialPortException.TYPE_NULL_NOT_PERMITTED);//since 2.1.0 -> NULL port name fix
+            throw new SerialPortException(this, "openPort()", SerialPortException.TYPE_NULL_NOT_PERMITTED);//since 2.1.0 -> NULL port name fix
         }
         if(portHandle == SerialNativeInterface.ERR_PORT_BUSY){
-            throw new SerialPortException(portName, "openPort()", SerialPortException.TYPE_PORT_BUSY);
+            throw new SerialPortException(this, "openPort()", SerialPortException.TYPE_PORT_BUSY);
         }
         else if(portHandle == SerialNativeInterface.ERR_PORT_NOT_FOUND){
-            throw new SerialPortException(portName, "openPort()", SerialPortException.TYPE_PORT_NOT_FOUND);
+            throw new SerialPortException(this, "openPort()", SerialPortException.TYPE_PORT_NOT_FOUND);
         }
         else if(portHandle == SerialNativeInterface.ERR_PERMISSION_DENIED){
-            throw new SerialPortException(portName, "openPort()", SerialPortException.TYPE_PERMISSION_DENIED);
+            throw new SerialPortException(this, "openPort()", SerialPortException.TYPE_PERMISSION_DENIED);
         }
         else if(portHandle == SerialNativeInterface.ERR_INCORRECT_SERIAL_PORT){
-            throw new SerialPortException(portName, "openPort()", SerialPortException.TYPE_INCORRECT_SERIAL_PORT);
+            throw new SerialPortException(this, "openPort()", SerialPortException.TYPE_INCORRECT_SERIAL_PORT);
         }
         portOpened = true;
         return true;
@@ -277,7 +277,7 @@ public class SerialPort {
         }
         boolean returnValue = serialInterface.setEventsMask(portHandle, mask);
         if(!returnValue){
-            throw new SerialPortException(portName, "setEventsMask()", SerialPortException.TYPE_CANT_SET_MASK);
+            throw new SerialPortException(this, "setEventsMask()", SerialPortException.TYPE_CANT_SET_MASK);
         }
         if(mask > 0){
             maskAssigned = true;
@@ -876,7 +876,7 @@ public class SerialPort {
      */
     private void checkPortOpened(String methodName) throws SerialPortException {
         if(!portOpened){
-            throw new SerialPortException(portName, methodName, SerialPortException.TYPE_PORT_NOT_OPENED);
+            throw new SerialPortException(this, methodName, SerialPortException.TYPE_PORT_NOT_OPENED);
         }
     }
 
@@ -1030,13 +1030,13 @@ public class SerialPort {
             eventListenerAdded = true;
         }
         else {
-            throw new SerialPortException(portName, "addEventListener()", SerialPortException.TYPE_LISTENER_ALREADY_ADDED);
+            throw new SerialPortException(this, "addEventListener()", SerialPortException.TYPE_LISTENER_ALREADY_ADDED);
         }
     }
 
     /**
      * Create new EventListener Thread depending on the type of operating system
-     * 
+     *
      * @since 0.8
      */
     private EventThread getNewEventThread() {
@@ -1059,7 +1059,7 @@ public class SerialPort {
     public boolean removeEventListener() throws SerialPortException {
         checkPortOpened("removeEventListener()");
         if(!eventListenerAdded){
-            throw new SerialPortException(portName, "removeEventListener()", SerialPortException.TYPE_CANT_REMOVE_LISTENER);
+            throw new SerialPortException(this, "removeEventListener()", SerialPortException.TYPE_CANT_REMOVE_LISTENER);
         }
         eventThread.terminateThread();
         setEventsMask(0);
@@ -1069,7 +1069,7 @@ public class SerialPort {
                     eventThread.join(5000);
                 }
                 catch (InterruptedException ex) {
-                    throw new SerialPortException(portName, "removeEventListener()", SerialPortException.TYPE_LISTENER_THREAD_INTERRUPTED);
+                    throw new SerialPortException(this, "removeEventListener()", SerialPortException.TYPE_LISTENER_THREAD_INTERRUPTED);
                 }
             }
         }
@@ -1110,11 +1110,11 @@ public class SerialPort {
                 int[][] eventArray = waitEvents();
                 for(int[] event : eventArray){
                     if(event[0] > 0 && !threadTerminated){
-                        eventListener.serialEvent(new SerialPortEvent(portName, event[0], event[1]));
+                        eventListener.serialEvent(new SerialPortEvent(SerialPort.this, event[0], event[1]));
                         //FIXME
                         /*if(methodErrorOccurred != null){
                             try {
-                                methodErrorOccurred.invoke(eventListener, new Object[]{new SerialPortException("port", "method", "exception")});
+                                methodErrorOccurred.invoke(eventListener, new Object[]{new SerialPortException(SerialPort.this, "method", "exception")});
                             }
                             catch (Exception ex) {
                                 System.out.println(ex);
@@ -1297,11 +1297,7 @@ public class SerialPort {
                                 break;
                         }
                         if(sendEvent){
-                            try {
-                                eventListener.serialEvent(new SerialPortEvent(readBytes(), portName, eventType, eventValue));
-                            } catch (SerialPortException ignored) {
-                                //TODO: How should this be handled?
-                            }
+                            eventListener.serialEvent(new SerialPortEvent(SerialPort.this, eventType, eventValue));
                         }
                     }
                 }

--- a/src/main/java/jssc/SerialPortEvent.java
+++ b/src/main/java/jssc/SerialPortEvent.java
@@ -30,10 +30,13 @@ package jssc;
  */
 public class SerialPortEvent {
 
-    private byte[] bytes;
-    private String portName;
+
+    private SerialPort port;
     private int eventType;
     private int eventValue;
+
+    @Deprecated
+    private String portName;
 
     public static final int RXCHAR = 1;
     public static final int RXFLAG = 2;
@@ -45,25 +48,32 @@ public class SerialPortEvent {
     public static final int ERR = 128;
     public static final int RING = 256;
 
-    public SerialPortEvent(byte[] bytes, String portName, int eventType, int eventValue){
-        this.bytes = bytes;
+    public SerialPortEvent(SerialPort port, int eventType, int eventValue){
+        this.port = port;
+        this.eventType = eventType;
+        this.eventValue = eventValue;
+    }
+
+    @Deprecated
+    public SerialPortEvent(String portName, int eventType, int eventValue){
         this.portName = portName;
         this.eventType = eventType;
         this.eventValue = eventValue;
     }
 
     /**
-     * Getting the bytes that set off this event
+     * Getting the port that set off this event
      */
-    public byte[] getBytes() {
-        return bytes;
+    public SerialPort getPort(){
+        return port;
     }
 
     /**
      * Getting port name which sent the event
      */
+    @Deprecated
     public String getPortName() {
-        return portName;
+        return port.getPortName();
     }
 
     /**

--- a/src/main/java/jssc/SerialPortEvent.java
+++ b/src/main/java/jssc/SerialPortEvent.java
@@ -30,6 +30,7 @@ package jssc;
  */
 public class SerialPortEvent {
 
+    private byte[] bytes;
     private String portName;
     private int eventType;
     private int eventValue;
@@ -44,10 +45,18 @@ public class SerialPortEvent {
     public static final int ERR = 128;
     public static final int RING = 256;
 
-    public SerialPortEvent(String portName, int eventType, int eventValue){
+    public SerialPortEvent(byte[] bytes, String portName, int eventType, int eventValue){
+        this.bytes = bytes;
         this.portName = portName;
         this.eventType = eventType;
         this.eventValue = eventValue;
+    }
+
+    /**
+     * Getting the bytes that set off this event
+     */
+    public byte[] getBytes() {
+        return bytes;
     }
 
     /**

--- a/src/main/java/jssc/SerialPortException.java
+++ b/src/main/java/jssc/SerialPortException.java
@@ -61,11 +61,22 @@ public class SerialPortException extends Exception {
      */
     final public static String TYPE_INCORRECT_SERIAL_PORT = "Incorrect serial port";
 
-    private String portName;
+    private SerialPort port;
     private String methodName;
     private String exceptionType;
 
-    public SerialPortException(String portName, String methodName, String exceptionType){
+    public SerialPortException(SerialPort port, String methodName, String exceptionType) {
+        super("Port name - " + port.getPortName() + "; Method name - " + methodName + "; Exception type - " + exceptionType + ".");
+        this.port = port;
+        this.methodName = methodName;
+        this.exceptionType = exceptionType;
+    }
+
+    @Deprecated
+    private String portName;
+
+    @Deprecated
+    public SerialPortException(String portName, String methodName, String exceptionType) {
         super("Port name - " + portName + "; Method name - " + methodName + "; Exception type - " + exceptionType + ".");
         this.portName = portName;
         this.methodName = methodName;
@@ -75,21 +86,29 @@ public class SerialPortException extends Exception {
     /**
      * Getting port name during operation with which the exception was called
      */
-    public String getPortName(){
-        return portName;
+    @Deprecated
+    public String getPortName() {
+        return port.getPortName();
+    }
+
+    /**
+     * Getting the port which threw the exception
+     */
+    public SerialPort getPort() {
+        return port;
     }
 
     /**
      * Getting method name during execution of which the exception was called
      */
-    public String getMethodName(){
+    public String getMethodName() {
         return methodName;
     }
 
     /**
      * Getting exception type
      */
-    public String getExceptionType(){
+    public String getExceptionType() {
         return exceptionType;
     }
 }


### PR DESCRIPTION
SerialPortEvent now also saves the byte buffer. It does introduce the SerialPortException to a function that didn't have it before. I'm not sure how this should be handled, thus this is WIP.

Reason for passing along the bytes:
https://github.com/java-native/jssc/issues/85#issuecomment-829255470
And from Slack (me):
> So, I'm not sure I understand the code correctly, but I don't think it's great to call `port.addEventListener(MyPortListener(port))` , the port given to the listener could be a different port than the port the listener is being assigned to. I'm currently working on a PR to have the bytes that trigger a `SerialPortEvent` given along with the event, so then in your own `PortListener`, you can do something like `event.getBytes()` to return a byte array of the latest message.

This makes the example implementation of the event listener in Java the following:
```Java
public static void main(String[] args) throws SerialPortException {
        SerialPort port = new SerialPort("COM10");
        port.openPort();
        port.setParams(BAUDRATE_9600, DATABITS_8, STOPBITS_1, PARITY_NONE);
        // port.setParams(9600, 8, 1, 0); // alternate technique
        int mask = SerialPort.MASK_RXCHAR + SerialPort.MASK_CTS + SerialPort.MASK_DSR;
        port.setEventsMask(mask);
        port.addEventListener(new MyPortListener() /* defined below */);
}

class MyPortListener implements SerialPortEventListener {
    public void serialEvent(SerialPortEvent event) {
        if (event.isRXCHAR()) { // data is available
            // read data, if 10 bytes available
            if (event.getEventValue() == 10) {
                byte[] buffer = event.getBytes();
                System.out.println(Arrays.toString(buffer));
            }
        } else if (event.isCTS()) { // CTS line has changed state
            if (event.getEventValue() == 1) { // line is ON
                System.out.println("CTS - ON");
            } else {
                System.out.println("CTS - OFF");
            }
        } else if (event.isDSR()) { // DSR line has changed state
            if (event.getEventValue() == 1) { // line is ON
                System.out.println("DSR - ON");
            } else {
                System.out.println("DSR - OFF");
            }
        }
    }
}
```

This code works for me, tested with 0,01 second interval between messages of 10 bytes.

Closes #87 