### PR TITLE
Move profile logic to antrun tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,12 @@ matrix:
           packages:
             - g++-mingw-w64-x86-64
     - os: linux
+      env: PROFILE=mingwaarch64
+      addons:
+        apt:
+          packages:
+            - clang
+    - os: linux
       env: PROFILE=armhf
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
           packages:
             - g++
     - os: linux
-      env: PROFILE=m32
+      env: PROFILE=x86
       addons:
         apt:
           packages:

--- a/ant/build.xml
+++ b/ant/build.xml
@@ -214,7 +214,10 @@
 
         <!-- Calculate path to sh.exe (Windows only) -->
         <property environment="env"/>
-        <property name="git.sh" value="${env.PROGRAMFILES}\git\bin\sh.exe"/>
+        <property name="git.sh.camel" value="${env.ProgramFiles}\git\bin\sh.exe"/>
+        <condition property="git.sh" value="${env.PROGRAMFILES}\git\bin\sh.exe" else="${git.sh.camel}">
+            <isset property="env.PROGRAMFILES"/>
+        </condition>
 
         <!-- Convert path to unix format -->
         <pathconvert targetos="unix" property="native.file.unix" refid="native.files"/>

--- a/pom.xml
+++ b/pom.xml
@@ -748,7 +748,7 @@
         <os.target.toolchain>MingwAarch64</os.target.toolchain>
 
         <os.target.name>windows</os.target.name>
-        <os.target.arch>arm_64</os.target.arch>
+        <os.target.arch>aarch_64</os.target.arch>
         <os.target.bitness>64</os.target.bitness>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -45,22 +45,14 @@
 
     <!-- profile-dependant flags a-z -->
     <cmake.compile.skip>false</cmake.compile.skip>
-    <cmake.build.args></cmake.build.args>
-    <cmake.generator.gccarch>IGNORE</cmake.generator.gccarch>
-    <cmake.generator.arg></cmake.generator.arg>
-    <cmake.generator.nativelibdir></cmake.generator.nativelibdir>
-    <cmake.generator.msvcplatform></cmake.generator.msvcplatform>
-    <cmake.generator.osxarchitectures></cmake.generator.osxarchitectures>
     <cmake.generator.skip>false</cmake.generator.skip>
-    <cmake.toolchain.file></cmake.toolchain.file>
     <javah.skip>false</javah.skip>
     <jar.dependencies.skip>true</jar.dependencies.skip>
-    <maven.assembly.id>${os.detected.name}-${os.detected.arch}-${os.detected.bitness}</maven.assembly.id>
 
     <!-- dependency versions a-z -->
     <dependency.junit.version>4.12</dependency.junit.version>
     <dependency.logback.version>1.2.3</dependency.logback.version>
-    <dependency.nativelibloader.version>2.3.6</dependency.nativelibloader.version>
+    <dependency.nativelibloader.version>2.3.5</dependency.nativelibloader.version>
 
     <!-- plugin versions a-z -->
     <plugin.animalsniffer.version>1.17</plugin.animalsniffer.version>
@@ -202,7 +194,7 @@
                 <exec executable="cmake" dir="${cmake.generated.directory}" failonerror="true">
                   <arg line="${project.basedir}"/>
                   <!-- Set the native lib output directory or leave blank to let CMake calculate -->
-                  <arg line="-DNATIVE_LIB_DIR=&quot;${cmake.generator.nativelibdir}&quot;"/>
+                  <arg line="${cmake.generator.nativelibdir}"/>
                   <!-- Pass-in maven's JAVA_HOME, helps resolve jni.h -->
                   <arg line="-DJAVA_HOME=&quot;${java.home}&quot;"/>
                   <!-- Final generator argument should be blank or one of:
@@ -230,46 +222,204 @@
                 <exec executable="cmake" dir="${cmake.generated.directory}" failonerror="true">
                   <arg line="--build"/>
                   <arg line="."/>
-                  <arg line="${cmake.build.args}"/>
+                  <arg line="${cmake.build.arg}"/>
                 </exec>
               </target>
             </configuration>
           </execution>
 
           <execution>
-            <id>maven-test-helper</id>
+            <id>calculate-cmake-args</id>
+            <phase>validate</phase>
+            <goals><goal>run</goal></goals>
+            <configuration>
+              <target name="calculate-target">
+                <!-- Calculate the target system -->
+                <!-- Note: Unlike maven, ant will preserve the value if already set -->
+                <property name="os.target.name" value="${os.detected.name}"/>
+                <property name="os.target.arch" value="${os.detected.arch}"/>
+                <property name="os.target.bitness" value="${os.detected.bitness}"/>
+                <property name="os.target.classifier" value="${os.target.name}-${os.target.arch}"/>
+
+                <!-- Guess the compiler based on host os -->
+                <!-- Windows: Assume MSVC -->
+                <condition property="use.msvc" value="true">
+                  <equals arg1="${os.detected.name}" arg2="windows"/>
+                </condition>
+                <!-- MacOS: Assume XCode -->
+                <condition property="use.xcode" value="true">
+                  <equals arg1="${os.detected.name}" arg2="osx"/>
+                </condition>
+                <!-- All others: Fallback on gcc -->
+                <condition property="use.gcc" value="true">
+                  <and>
+                    <not>
+                      <equals arg1="${os.detected.name}" arg2="osx"/>
+                    </not>
+                    <not>
+                      <equals arg1="${os.detected.name}" arg2="windows"/>
+                    </not>
+                  </and>
+                </condition>
+
+                <!-- Translate "NATIVE_LIB_DIR" prefix portion:
+                  - os.target.arch: must compare to a valid os value from os-maven-plugin
+                  - os.target.nativelib.suffix: must be set to a valid directory os value from native-lib-loader plugin
+                -->
+                <property name="nativelibdir.prefix" value="${os.target.name}"/>
+
+                <!-- Translate "NATIVE_LIB_DIR" suffix portion:
+                  - os.target.arch: must compare to a valid arch value from os-maven-plugin
+                  - os.target.nativelib.suffix: must be set to a valid directory suffix value from native-lib-loader plugin
+                -->
+                <!-- "x86_64" <=> "64" -->
+                <condition property="nativelibdir.suffix" value="64">
+                  <equals arg1="${os.target.arch}" arg2="x86_64"/>
+                </condition>
+                <!-- "x86_32" <=> "32" -->
+                <condition property="nativelibdir.suffix" value="32">
+                  <equals arg1="${os.target.arch}" arg2="x86_32"/>
+                </condition>
+                <!-- "aarch_64" <=> "arm64" -->
+                <condition property="nativelibdir.suffix" value="arm64">
+                  <equals arg1="${os.target.arch}" arg2="aarch_64"/>
+                </condition>
+                <!-- "arm_32" <=> "arm" -->
+                <condition property="nativelibdir.suffix" value="arm">
+                  <equals arg1="${os.target.arch}" arg2="arm_32"/>
+                </condition>
+                <!-- "ppc_64" <=> "ppc" -->
+                <condition property="nativelibdir.suffix" value="ppc">
+                  <equals arg1="${os.target.arch}" arg2="ppc_64"/>
+                </condition>
+
+                <!-- Set cmake property "NATIVE_LIB_DIR" -->
+                <property name="cmake.generator.nativelibdir" value="-DNATIVE_LIB_DIR=&quot;${nativelibdir.prefix}_${nativelibdir.suffix}&quot;"/>
+
+                <!-- Handle toolchain files -->
+                <condition property="cmake.generator.arg" value="-DCMAKE_TOOLCHAIN_FILE=&quot;${project.basedir}/toolchain/${os.target.toolchain}.cmake&quot;">
+                  <isset property="os.target.toolchain"/>
+                </condition>
+
+                <!-- Setup maven assembly id -->
+                <property name="maven.assembly.id" value="${os.target.name}-${os.target.arch}-${os.target.bitness}"/>
+              </target>
+              <exportAntProperties>true</exportAntProperties>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>calculate-msvc</id>
+            <phase>validate</phase>
+            <goals><goal>run</goal></goals>
+            <configuration>
+              <target name="calculate-msvc" if="use.msvc">
+                <!-- Translate arch to msvc format -->
+                <!--
+                  - os.target.arch: must compare to a valid os value from os-maven-plugin
+                  - msvc.platform: must be set to a valid value from cmake "-A" option for visual studio platform selection
+                -->
+                <!-- "x86_64" <=> "x64" -->
+                <condition property="msvc.arch" value="x64">
+                  <equals arg1="${os.target.arch}" arg2="x86_64"/>
+                </condition>
+                <!-- "x86_32" <=> "Win32" -->
+                <condition property="msvc.arch" value="Win32">
+                  <equals arg1="${os.target.arch}" arg2="x86_32"/>
+                </condition>
+                <!-- "arm_32" <=> "ARM" -->
+                <condition property="msvc.arch" value="ARM">
+                  <equals arg1="${os.target.arch}" arg2="arm_32"/>
+                </condition>
+                <!-- "aarch_64" <=> "ARM64" -->
+                <condition property="msvc.arch" value="ARM64">
+                  <equals arg1="${os.target.arch}" arg2="aarch_64"/>
+                </condition>
+
+                <!-- Set cmake property "CMAKE_GENERATOR_PLATFORM" -->
+                <property name="cmake.generator.arg" value="-DCMAKE_GENERATOR_PLATFORM=${msvc.arch}"/>
+
+                <!-- Set cmake build to release -->
+                <property name="cmake.build.arg" value="--config Release"/>
+              </target>
+              <exportAntProperties>true</exportAntProperties>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>calculate-xcode</id>
+            <phase>validate</phase>
+            <goals><goal>run</goal></goals>
+            <configuration>
+              <target name="calculate-xcode" if="use.xcode">
+                <!-- Translate arch to xcode format -->
+                <!--
+                  - os.target.arch: must compare to a valid os value from os-maven-plugin
+                  - xcode.arch: must be set to a valid value llvm/clang triple arch type
+                -->
+                <!-- x86_64 <=> x86_64 -->
+                <condition property="xcode.arch" value="x86_64">
+                  <equals arg1="${os.target.arch}" arg2="x86_64"/>
+                </condition>
+                <!-- x86_32 <=> x86 -->
+                <condition property="xcode.arch" value="x86">
+                  <equals arg1="${os.target.arch}" arg2="x86_32"/>
+                </condition>
+                <!-- aarch_64 <=> arm64 -->
+                <condition property="xcode.arch" value="arm64">
+                  <equals arg1="${os.target.arch}" arg2="aarch_64"/>
+                </condition>
+                <!-- arm_32 <=> arm -->
+                <condition property="xcode.arch" value="arm">
+                  <equals arg1="${os.target.arch}" arg2="arm_32"/>
+                </condition>
+
+                <!-- Set cmake property "CMAKE_OSX_ARCHITECTURES" -->
+                <property name="cmake.generator.arg" value="-DCMAKE_OSX_ARCHITECTURES=${xcode.arch}"/>
+              </target>
+              <exportAntProperties>true</exportAntProperties>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>set-missing-properties</id>
+            <phase>validate</phase>
+            <goals><goal>run</goal></goals>
+            <configuration>
+              <target name="set-missing-properties">
+                <!-- makes sure any unset cmake properties fallback to a blank value  -->
+                <!-- this works because ant properties cannot be changed once set-->
+                <property description="fallback value" name="cmake.build.arg" value=""/>
+                <property description="fallback value" name="cmake.generator.arg" value=""/>
+                <property description="fallback value" name="cmake.generator.nativelibdir" value=""/>
+              </target>
+              <exportAntProperties>true</exportAntProperties>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>calculate-testable</id>
             <phase>compile</phase>
             <goals><goal>run</goal></goals>
             <configuration>
-              <exportAntProperties>true</exportAntProperties>
-              <target name="maven-test-helper">
-                <!-- Calculate the target system -->
-                <property name="maven.host.system" value="${os.arch} [${os.name}]"/>
-                <condition property="maven.target.system" value="${maven.test.skip.compare}" else="${os.arch} [${os.name}]">
-                  <isset property="maven.test.skip.compare"/>
+              <target name="calculate-testable">
+                <!-- Calculate if tests will run -->
+                <condition property="maven.test.skip" value="true" else="true">
+                  <!-- Honor existing flag if set -->
+                  <and>
+                    <not>
+                      <isset property="maven.test.skip"/>
+                    </not>
+                    <!-- Run tests if detected system matches target system -->
+                    <equals arg1="${os.target.classifier}" arg2="${os.detected.classifier}"/>
+                  </and>
                 </condition>
 
                 <!-- Summarize host/target -->
                 <echo level="info">Tests will run only if the TARGET and HOST match:${line.separator}${line.separator}</echo>
-                <echo level="info">TARGET:  ${maven.target.system}</echo>
-                <echo level="info">HOST:    ${maven.host.system}</echo>
+                <echo level="info">TARGET:   ${os.target.classifier}</echo>
+                <echo level="info">DETECTED: ${os.detected.classifier}</echo>
                 <echo level="info"/>
-
-                <!-- Determine if tests should run -->
-                <condition property="maven.test.skip" value="true">
-                  <and>
-                    <!-- Honor value if already set -->
-                    <not>
-                      <isset property="maven.test.skip"/>
-                    </not>
-                    <!-- Make sure we have a value to compare
-                    <isset property="maven.test.skip.compare"/> -->
-                    <!-- Assume unit tests are impossible if host and target systems are mismatched -->
-                    <not>
-                      <equals arg1="${maven.host.system}" arg2="${maven.target.system}"/>
-                    </not>
-                  </and>
-                </condition>
 
                 <!-- Negate result for human readability -->
                 <condition property="maven.test.message" value="Tests will NOT run" else="Tests WILL run">
@@ -278,6 +428,26 @@
                 <echo level="info">===== ${maven.test.message} =====</echo>
                 <echo level="info"/>
               </target>
+              <exportAntProperties>true</exportAntProperties>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>show-file-info</id>
+            <phase>install</phase>
+            <goals><goal>run</goal></goals>
+            <configuration>
+              <target name="show-file-info" unless="use.msvc">
+                <!-- Show binary output file information -->
+                <property name="native.dir" value="${project.build.directory}/cmake/natives/${nativelibdir.prefix}_${nativelibdir.suffix}"/>
+                <fileset id="native.files" dir="${native.dir}" includes="*"/>
+                <echo level="info">File information:</echo>
+                <exec executable="file">
+                  <arg value="${native.dir}/${toString:native.files}"/>
+                </exec>
+                <echo level="info"></echo>
+              </target>
+              <exportAntProperties>true</exportAntProperties>
             </configuration>
           </execution>
 
@@ -493,254 +663,101 @@
       </properties>
     </profile>
 
-    <!-- Set os.detected.arch; may be overridden lower -->
-    <profile>
-      <id>aarch64_detected</id>
-      <activation>
-        <os>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
-      <properties>
-        <os.detected.arch>aarch_64</os.detected.arch>
-      </properties>
-    </profile>
-    <profile>
-      <id>x86_64_detected</id>
-      <activation>
-        <os>
-          <arch>amd64</arch>
-        </os>
-      </activation>
-      <properties>
-        <os.detected.arch>x86_64</os.detected.arch>
-      </properties>
-    </profile>
-    <profile>
-      <id>x86_detected</id>
-      <activation>
-        <os>
-          <arch>x86</arch>
-        </os>
-      </activation>
-      <properties>
-        <os.detected.arch>x86_32</os.detected.arch>
-      </properties>
-    </profile>
-
-    <!-- cmake generic arm64 profile (all platforms) -->
+    <!-- Cross compile for aarch64 -->
     <profile>
       <id>aarch64</id>
-      <activation>
-        <property>
-          <name>os.detected.arch</name>
-          <value>aarch_64</value>
-        </property>
-      </activation>
       <properties>
-        <os.detected.arch>aarch_64</os.detected.arch>
-        <os.detected.bitness>64</os.detected.bitness>
-        <cmake.generator.nativelibdir>${os.detected.name}_arm64</cmake.generator.nativelibdir>
-        <!-- msvc only -->
-        <cmake.generator.msvcplatform>ARM64</cmake.generator.msvcplatform>
-        <!-- macos only -->
-        <cmake.generator.osxarchitectures>arm64</cmake.generator.osxarchitectures>
-        <!-- used to calculate if java is running natively -->
-        <maven.test.skip.compare>aarch64 [${os.name}]</maven.test.skip.compare>
+        <os.target.arch>aarch_64</os.target.arch>
       </properties>
     </profile>
 
-    <!-- cmake generic x86_64 profile (all platforms) -->
+    <!-- Cross compile for x86_64 -->
     <profile>
       <id>x86_64</id>
-      <activation>
-        <property>
-          <name>os.detected.arch</name>
-          <value>x86_64</value>
-        </property>
-      </activation>
       <properties>
-        <os.detected.arch>x86_64</os.detected.arch>
-        <os.detected.bitness>64</os.detected.bitness>
-        <cmake.generator.nativelibdir>${os.detected.name}_64</cmake.generator.nativelibdir>
-        <!-- msvc only -->
-        <cmake.generator.msvcplatform>x64</cmake.generator.msvcplatform>
-        <!-- macos only -->
-        <cmake.generator.osxarchitectures>x86_64</cmake.generator.osxarchitectures>
-        <!-- linux only -->
-        <cmake.generator.gccarch>M64</cmake.generator.gccarch>
-        <!-- used to calculate if java is running natively -->
-        <maven.test.skip.compare>amd64 [${os.name}]</maven.test.skip.compare>
+        <os.target.arch>x86_64</os.target.arch>
       </properties>
     </profile>
 
-    <!-- cmake generic x86 profile (all platforms) -->
+    <!-- Cross compile for x86 -->
     <profile>
       <id>x86</id>
-      <activation>
-        <property>
-          <name>os.detected.arch</name>
-          <value>x86_32</value>
-        </property>
-      </activation>
       <properties>
-        <os.detected.arch>x86_32</os.detected.arch>
-        <os.detected.bitness>32</os.detected.bitness>
-        <cmake.generator.nativelibdir>${os.detected.name}_32</cmake.generator.nativelibdir>
-        <!-- msvc only -->
-        <cmake.generator.msvcplatform>Win32</cmake.generator.msvcplatform>
-        <!-- macos only -->
-        <cmake.generator.osxarchitectures>x86_64</cmake.generator.osxarchitectures>
-        <!-- linux only -->
-        <cmake.generator.gccarchitecture>M32</cmake.generator.gccarchitecture>
-        <!-- used to calculate if java is running natively -->
-        <maven.test.skip.compare>x86 [${os.name}]</maven.test.skip.compare>
+        <os.target.arch>x86_32</os.target.arch>
       </properties>
     </profile>
 
-    <!-- cmake msvc profile, must occur after generic profile above -->
-    <profile>
-      <id>msvc</id>
-      <activation>
-        <os>
-          <family>windows</family>
-        </os>
-      </activation>
-      <properties>
-        <cmake.generator.arg>-DCMAKE_GENERATOR_PLATFORM=${cmake.generator.msvcplatform}</cmake.generator.arg>
-        <!-- Release is needed on Windows per https://stackoverflow.com/a/20423820/3196753 -->
-        <cmake.build.args>--config Release</cmake.build.args>
-      </properties>
-    </profile>
-
-    <!-- cmake linux profile, must occur after generic profile above -->
-    <profile>
-      <id>linux</id>
-      <activation>
-        <os>
-          <!-- warning, "unix" will match "macos" too -->
-          <family>unix</family>
-        </os>
-      </activation>
-      <properties>
-        <!-- Should be one of:
-             FORCE_M32
-             FORCE_M64
-        -->
-        <cmake.generator.arg>"-DFORCE_${cmake.generator.gccarch}=True"</cmake.generator.arg>
-      </properties>
-    </profile>
-
-    <!-- cmake macos profile, must occur after generic profile above -->
-    <profile>
-      <id>macos</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
-      </activation>
-      <properties>
-        <cmake.generator.arg>-DCMAKE_OSX_ARCHITECTURES=${cmake.generator.osxarchitectures}</cmake.generator.arg>
-      </properties>
-    </profile>
-
-    <!-- cmake mingw32 profile, must occur after os profiles above -->
+    <!-- Cross compile for win32 using mingw -->
     <profile>
       <id>mingw32</id>
       <properties>
-        <!-- override os-maven-plugin values -->
-        <os.detected.name>windows</os.detected.name>
-        <os.detected.arch>x86_32</os.detected.arch>
-        <os.detected.bitness>32</os.detected.bitness>
-        <cmake.generator.arg>-DCMAKE_TOOLCHAIN_FILE="${project.basedir}/toolchain/Mingw${os.detected.bitness}.cmake"</cmake.generator.arg>
-        <cmake.generator.nativelibdir>${os.detected.name}_${os.detected.bitness}</cmake.generator.nativelibdir>
-        <!-- used to calculate if Java is running natively -->
-        <maven.test.skip.compare>x86 [Windows]</maven.test.skip.compare>
+        <os.target.toolchain>Mingw32</os.target.toolchain>
+
+        <os.target.name>windows</os.target.name>
+        <os.target.arch>x86_32</os.target.arch>
+        <os.target.bitness>32</os.target.bitness>
       </properties>
     </profile>
 
-    <!-- cmake mingw64 profile, must occur after os profiles above -->
+    <!-- Cross compile for win64 using mingw -->
     <profile>
       <id>mingw64</id>
       <properties>
-        <os.detected.name>windows</os.detected.name>
-        <os.detected.arch>x86_64</os.detected.arch>
-        <os.detected.bitness>64</os.detected.bitness>
-        <cmake.generator.arg>-DCMAKE_TOOLCHAIN_FILE="${project.basedir}/toolchain/Mingw${os.detected.bitness}.cmake"</cmake.generator.arg>
-        <cmake.generator.nativelibdir>${os.detected.name}_${os.detected.bitness}</cmake.generator.nativelibdir>
-        <!-- used to calculate if Java is running natively -->
-        <maven.test.skip.compare>amd64 [Windows]</maven.test.skip.compare>
+        <os.target.toolchain>Mingw64</os.target.toolchain>
+
+        <os.target.name>windows</os.target.name>
+        <os.target.arch>x86_64</os.target.arch>
+        <os.target.bitness>64</os.target.bitness>
       </properties>
     </profile>
 
-    <!-- cmake mingwaarch64 profile, must occur after os profiles above -->
+    <!-- Cross compile for win arm64 using mingw -->
     <profile>
       <id>mingwaarch64</id>
       <properties>
-        <os.detected.name>windows</os.detected.name>
-        <os.detected.arch>arm_64</os.detected.arch>
-        <os.detected.bitness>64</os.detected.bitness>
-        <cmake.generator.arg>-DCMAKE_TOOLCHAIN_FILE="${project.basedir}/toolchain/MingwAarch64.cmake"</cmake.generator.arg>
-        <cmake.generator.nativelibdir>windows_arm64</cmake.generator.nativelibdir>
-        <!-- used to calculate if Java is running natively -->
-        <maven.test.skip.compare>aarch64 [Windows]</maven.test.skip.compare>
+        <os.target.toolchain>MingwAarch64</os.target.toolchain>
+
+        <os.target.name>windows</os.target.name>
+        <os.target.arch>arm_64</os.target.arch>
+        <os.target.bitness>64</os.target.bitness>
       </properties>
     </profile>
 
-    <!-- cmake arm soft float profile, must occur after os profiles above -->
-    <profile>
-      <id>armsf</id>
-      <properties>
-        <os.detected.name>linux</os.detected.name>
-        <os.detected.arch>arm_32</os.detected.arch>
-        <os.detected.bitness>32</os.detected.bitness>
-        <cmake.generator.arg>-DCMAKE_TOOLCHAIN_FILE="${project.basedir}/toolchain/Armsf.cmake"</cmake.generator.arg>
-        <cmake.generator.nativelibdir>${os.detected.name}_arm</cmake.generator.nativelibdir>
-        <!-- used to calculate if Java is running natively -->
-        <maven.test.skip.compare>armsf [Linux]</maven.test.skip.compare>
-      </properties>
-    </profile>
-
-    <!-- cmake arm hard float profile, must occur after os profiles above -->
-    <profile>
-      <id>armhf</id>
-      <properties>
-        <os.detected.name>linux</os.detected.name>
-        <os.detected.arch>arm_32</os.detected.arch>
-        <os.detected.bitness>32</os.detected.bitness>
-        <!-- TODO: namespace conflict with arm soft float library.  See also cmake's HAS_FPU -->
-        <cmake.generator.arg>-DCMAKE_TOOLCHAIN_FILE="${project.basedir}/toolchain/Armhf.cmake"</cmake.generator.arg>
-        <cmake.generator.nativelibdir>${os.detected.name}_arm</cmake.generator.nativelibdir>
-        <!-- used to calculate if Java is running natively -->
-        <maven.test.skip.compare>armhf [Linux]</maven.test.skip.compare>
-      </properties>
-    </profile>
-
-    <!-- cmake powerpc profile, must occur after os profiles above -->
+    <!-- Cross compile for ppc64 -->
     <profile>
       <id>ppc64</id>
       <properties>
-        <os.detected.name>linux</os.detected.name>
-        <os.detected.arch>ppc_64</os.detected.arch>
-        <os.detected.bitness>64</os.detected.bitness>
-        <cmake.generator.arg>-DCMAKE_TOOLCHAIN_FILE="${project.basedir}/toolchain/Ppc64.cmake"</cmake.generator.arg>
-        <cmake.generator.nativelibdir>${os.detected.name}_ppc</cmake.generator.nativelibdir>
-        <!-- used to calculate if Java is running natively -->
-        <maven.test.skip.compare>ppc64 [Linux]</maven.test.skip.compare>
+        <os.target.toolchain>Ppc64</os.target.toolchain>
+
+        <os.target.name>linux</os.target.name>
+        <os.target.arch>ppc_64</os.target.arch>
+        <os.target.bitness>64</os.target.bitness>
       </properties>
     </profile>
 
-    <!-- cmake aarch64 linux profile, must occur after os profiles above -->
+    <!-- Cross compile for arm32hf (hardware floating point) -->
     <profile>
-      <id>linux-aarch64</id>
+      <id>armhf</id>
       <properties>
-        <os.detected.name>linux</os.detected.name>
-        <os.detected.arch>arm_64</os.detected.arch>
-        <os.detected.bitness>64</os.detected.bitness>
-        <cmake.generator.arg>-DCMAKE_TOOLCHAIN_FILE="${project.basedir}/toolchain/Aarch64.cmake"</cmake.generator.arg>
-        <cmake.generator.nativelibdir>${os.detected.name}_arm64</cmake.generator.nativelibdir>
-        <!-- used to calculate if Java is running natively -->
-        <maven.test.skip.compare>aarch64 [Linux]</maven.test.skip.compare>
+        <os.target.toolchain>Armhf</os.target.toolchain>
+
+        <os.target.name>linux</os.target.name>
+        <!-- TODO: namespace conflict with arm soft float library.  See also cmake's HAS_FPU -->
+        <os.target.arch>arm_32</os.target.arch>
+        <os.target.bitness>32</os.target.bitness>
+      </properties>
+    </profile>
+
+    <!-- Cross compile for arm32sf (software floating point) -->
+    <profile>
+      <id>armsf</id>
+      <properties>
+        <os.target.toolchain>Armsf</os.target.toolchain>
+
+        <os.target.name>linux</os.target.name>
+        <!-- TODO: namespace conflict with arm hard float library.  See also cmake's HAS_FPU -->
+        <os.target.arch>arm_32</os.target.arch>
+        <os.target.bitness>32</os.target.bitness>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,14 @@
                 <property name="cmake.generator.nativelibdir" value="-DNATIVE_LIB_DIR=&quot;${nativelibdir.prefix}_${nativelibdir.suffix}&quot;"/>
 
                 <!-- Handle toolchain files -->
+                <!-- "linux" + "aarch_64" <=> "Aarch64.cmake" -->
+                <condition property="os.target.toolchain" value="Aarch64">
+                  <and>
+                    <equals arg1="${os.target.arch}" arg2="aarch_64"/>
+                    <equals arg1="${os.detected.name}" arg2="linux"/>
+                  </and>
+                </condition>
+                <!-- Others should be set in maven profile -->
                 <condition property="cmake.generator.arg" value="-DCMAKE_TOOLCHAIN_FILE=&quot;${project.basedir}/toolchain/${os.target.toolchain}.cmake&quot;">
                   <isset property="os.target.toolchain"/>
                 </condition>

--- a/pom.xml
+++ b/pom.xml
@@ -445,13 +445,35 @@
             <phase>install</phase>
             <goals><goal>run</goal></goals>
             <configuration>
-              <target name="show-file-info" unless="use.msvc">
+              <target name="show-file-info">
                 <!-- Show binary output file information -->
                 <property name="native.dir" value="${project.build.directory}/cmake/natives/${nativelibdir.prefix}_${nativelibdir.suffix}"/>
                 <fileset id="native.files" dir="${native.dir}" includes="*"/>
                 <echo level="info">File information:</echo>
-                <exec executable="file">
-                  <arg value="${native.dir}/${toString:native.files}"/>
+
+                <!-- Calculate path to sh.exe (Windows only) -->
+                <property environment="env"/>
+                <property name="git.sh" value="${env.PROGRAMFILES}\git\bin\sh.exe"/>
+
+                <!-- Convert path to unix format -->
+                <pathconvert targetos="unix" property="native.file.unix" refid="native.files"/>
+
+                <!-- Prepare command ("file" on unix, "sh.exe" on Windows)-->
+                <condition property="exec.command" value="${git.sh}" else="file">
+                  <resourceexists>
+                    <file file="${git.sh}"/>
+                  </resourceexists>
+                </condition>
+
+                <!-- Prepare argument line -->
+                <condition property="exec.argline" value="-c &quot;file '${native.file.unix}'&quot;" else="'${native.file.unix}'">
+                  <resourceexists>
+                    <file file="${git.sh}"/>
+                  </resourceexists>
+                </condition>
+
+                <exec executable="${exec.command}">
+                  <arg line="${exec.argline}"/>
                 </exec>
                 <echo level="info"></echo>
               </target>

--- a/src/main/java/jssc/SerialPortList.java
+++ b/src/main/java/jssc/SerialPortList.java
@@ -330,16 +330,12 @@ public class SerialPortList {
                     String fileName = file.getName();
                     if(!file.isDirectory() && !file.isFile() && pattern.matcher(fileName).find()){
                         String portName = searchPath + fileName;
-             //           long portHandle = serialInterface.openPort(portName, false);//Open port without TIOCEXCL 
-                           // For linux ttyS0..31 serial ports check existence by opening each of them
-                        if (fileName.startsWith("ttyS")) {
-	                        long portHandle = serialInterface.openPort(portName, false);//Open port without TIOCEXCL
-	                        if(portHandle < 0 && portHandle != SerialNativeInterface.ERR_PORT_BUSY){
-	                            continue;
-	                        }
-	                        else if(portHandle != SerialNativeInterface.ERR_PORT_BUSY) {
-	                            serialInterface.closePort(portHandle);
-	                        }
+                        long portHandle = serialInterface.openPort(portName, false);//Open port without TIOCEXCL
+                        if(portHandle < 0 && portHandle != SerialNativeInterface.ERR_PORT_BUSY){
+                            continue;
+                        }
+                        else if(portHandle != SerialNativeInterface.ERR_PORT_BUSY) {
+                            serialInterface.closePort(portHandle);
                         }
                         portsTree.add(portName);
                     }

--- a/src/main/java/jssc/SerialPortList.java
+++ b/src/main/java/jssc/SerialPortList.java
@@ -330,12 +330,16 @@ public class SerialPortList {
                     String fileName = file.getName();
                     if(!file.isDirectory() && !file.isFile() && pattern.matcher(fileName).find()){
                         String portName = searchPath + fileName;
-                        long portHandle = serialInterface.openPort(portName, false);//Open port without TIOCEXCL
-                        if(portHandle < 0 && portHandle != SerialNativeInterface.ERR_PORT_BUSY){
-                            continue;
-                        }
-                        else if(portHandle != SerialNativeInterface.ERR_PORT_BUSY) {
-                            serialInterface.closePort(portHandle);
+             //           long portHandle = serialInterface.openPort(portName, false);//Open port without TIOCEXCL 
+                           // For linux ttyS0..31 serial ports check existence by opening each of them
+                        if (fileName.startsWith("ttyS")) {
+	                        long portHandle = serialInterface.openPort(portName, false);//Open port without TIOCEXCL
+	                        if(portHandle < 0 && portHandle != SerialNativeInterface.ERR_PORT_BUSY){
+	                            continue;
+	                        }
+	                        else if(portHandle != SerialNativeInterface.ERR_PORT_BUSY) {
+	                            serialInterface.closePort(portHandle);
+	                        }
                         }
                         portsTree.add(portName);
                     }

--- a/toolchain/MingwAarch64.cmake
+++ b/toolchain/MingwAarch64.cmake
@@ -1,5 +1,28 @@
 set(CMAKE_SYSTEM_NAME Windows)
-set(TOOLCHAIN_LOCATION "$ENV{HOME}/llvm-mingw/bin")
+
+# URL for llvm-mingw
+set(URL "https://github.com/mstorsjo/llvm-mingw/releases/download/20201020/llvm-mingw-20201020-msvcrt-ubuntu-18.04.tar.xz")
+set(SHA256 "96e94e469665ee5632fff32a19b589ae1698859189d85615f3062b1544510b75")
+get_filename_component(ARCHIVE_NAME "${URL}" NAME)
+set(ARCHIVE "${CMAKE_BINARY_DIR}/llvm-mingw/${ARCHIVE_NAME}")
+
+# Try to predict the subdirectory name from the file name
+string(REPLACE ".tar.xz" "" SUBDIR "${ARCHIVE_NAME}")
+
+# Prevent extract process from running more than once
+if(NOT TOOLCHAIN_LOCATION)
+  if(NOT EXISTS "${CMAKE_BINARY_DIR}/llvm-mingw/${SUBDIR}")
+    if(NOT EXISTS "${ARCHIVE}")
+      file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/llvm-mingw")
+      message(STATUS "Downloading ${URL} to ${ARCHIVE}...")
+      file(DOWNLOAD ${URL} ${ARCHIVE} TIMEOUT 60 EXPECTED_HASH SHA256=${SHA256})
+    endif()
+    message(STATUS "Extracting ${ARCHIVE} to ${CMAKE_BINARY_DIR}/llvm-mingw/${SUBDIR}/...")
+    file(ARCHIVE_EXTRACT INPUT "${ARCHIVE}" DESTINATION "${CMAKE_BINARY_DIR}/llvm-mingw")
+  endif()
+endif()
+
+set(TOOLCHAIN_LOCATION "${CMAKE_BINARY_DIR}/llvm-mingw/${SUBDIR}/bin")
 set(TOOLCHAIN_PREFIX "${TOOLCHAIN_LOCATION}/aarch64-w64-mingw32")
 set(CMAKE_C_COMPILER "${TOOLCHAIN_PREFIX}-gcc")
 set(CMAKE_CXX_COMPILER "${TOOLCHAIN_PREFIX}-g++")


### PR DESCRIPTION
Since #91 was merged, the profile logic for detecting and setting various build properties was failing in certain scenarios (e.g. One JVM or host OS may report `os.arch=x86_64`, another reports `os.arch=arm64`, etc)

The `os-maven-plugin` is designed to handle these exact scenarios, however it's properties are [not available at profile-activation time](https://github.com/trustin/os-maven-plugin/issues/23).

This PR aims to fix that by moving maven's profile logic into dedicated antrun tasks, which are still quite hard to read (a nuance of ant in general), but now well organized much easier to read than the spiderwebs of profile rules we had previously.

This adds the following antrun tasks:

### calculate-target
Calculates the target build system properties, specifically:
   * `os.target.name`
   * `os.target.arch`
   * `os.target.bitness`
   * `os.target.classifier`


These names were chosen to match the `os-maven-plugin` convention of `os.detected.name`, `os.detected.arch`, etc.  If the target system isn't specified, it'll default to the detected system.

Other properties set by `calculate-target`
   * `cmake.generator.nativelibdir`
   * `cmake.generator.arg` (only if a toolchain file is provided)
   * `maven.assembly.id`

Last, this target is responsible for attaching a toolchain file to cmake, if needed. 
    
### calculate-msvc
   * Sets various cmake compiler options specific to the Microsoft Visual C compiler.
   * This is defaulted to ON for Windows, we don't yet support `gcc`, `clang` through like msys2 or cygwin yet.  It would be relatively easy to support these down the road if needed.
   * Sets a special `cmake.build.arg` needed for MSVC-only (to trigger Release builds only, not Debug builds)
   
### calculate-xcode
   * Sets various cmake compiler options specific to the Clang/LLVM compiler
   * This is defaulted to ON for MacOS.  We don't yet support `gcc` or other compilers on Mac.

### calculate-gcc
   * Sets various cmake compiler options specific to the GNU GCC compiler, assuming a Linux host.
   * This is defaulted to ON for all other OSs, which might cause issues with stuff like Solaris.  We don't official support `clang` or other compilers on Linux, but historically these are drop-in replacements and should work.  Note, `clang` is required for cross-compiling Windows ARM64 binaries from Linux, but this is handled through a dedicated toolchain file (see `calculate-target`)

### calculate-testable
   * This task is renamed, mostly unchanged, calculated and echos if tests will run by comparing `os.target.classifier` to `os.detected.classifier` and setting `maven.test.skip` appropriately.

### show-file-info
   * This is a new task who's only job is to call `file` (e.g. `file target/cmake/natives/macos_64/libjssc.dyllib`) and echo the value returned to the screen.  @GMKennedy and I used this command a lot testing #91 and I shimmed it in to save some time testing. If supported the `file` command should state the target architecture, which is especially useful for cross-compiling.  The command will only run on unix variants like MacOS and Linux.  At time of writing, Windows doesn't have a `file` command.

Before merging:
* @GMKennedy can you help test the various build profiles? I haven't tested `mingw`, `ppc` or `armhf` profiles yet.
* If possible, I'd love to move these antrun tasks to a dedicated `build.xml` file, but when doing so, I couldn't get the properties to propagate back to Maven.  Any help here is greatly appreciated.

