### PR TITLE
Skip ant task when not building natives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
             <phase>install</phase>
             <goals><goal>run</goal></goals>
             <configuration>
+              <skip>${cmake.build.skip}</skip>
               <target>
                 <ant dir="ant" target="show-file-info"/>
               </target>


### PR DESCRIPTION
The ant task `show-file-info` only makes sense if the natives were built, which does not always happen e.g. in `package` profile, required for release.