### PR TITLE
Automatic release to Maven central

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -1,0 +1,29 @@
+name: Maven Central Relase
+on: workflow_dispatch
+
+env:
+  MAVEN_CLI: -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: adopt
+          server-id: ossrh
+          server-username: OSSRH_TOKEN_USERNAME
+          server-password: OSSRH_TOKEN_PASSWORD
+          gpg-private-key: ${{ secrets.JAVA_NATIVE_PGP_KEY }}
+          gpg-passphrase: PGP_KEY_PASSPHRASE
+      - name: Prep Maven Repo
+        run: mvn ${MAVEN_CLI} dependency:resolve-plugins dependency:resolve
+      - name: Publish artifacts to Maven Central
+        run: mvn ${MAVEN_CLI} clean deploy -P package,maven-central-release
+        env:
+          OSSRH_TOKEN_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}
+          OSSRH_TOKEN_PASSWORD: ${{ secrets.OSSRH_TOKEN_PASSWORD }}
+          PGP_KEY_PASSPHRASE: ${{ secrets.JAVA_NATIVE_PGP_KEY_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,11 @@
     <plugin.assembly.version>3.1.1</plugin.assembly.version>
     <plugin.compiler.version>3.8.0</plugin.compiler.version>
     <plugin.enforcer.version>3.0.0-M3</plugin.enforcer.version>
+    <plugin.gpg.version>3.0.1</plugin.gpg.version>
     <plugin.jar.version>3.1.1</plugin.jar.version>
     <plugin.javadoc.version>3.1.1</plugin.javadoc.version>
     <plugin.nar.version>3.6.0</plugin.nar.version>
+    <plugin.nexus-staging.version>1.6.7</plugin.nexus-staging.version>
     <plugin.osmaven.version>1.7.0</plugin.osmaven.version>
     <plugin.signature.version>1.1</plugin.signature.version>
     <plugin.source.version>3.0.1</plugin.source.version>
@@ -416,7 +418,7 @@
              <execution>
                <id>attach-sources</id>
                <goals>
-                 <goal>jar</goal>
+                 <goal>jar-no-fork</goal>
                </goals>
              </execution>
            </executions>
@@ -541,6 +543,47 @@
         <os.target.arch>arm_32</os.target.arch>
         <os.target.bitness>32</os.target.bitness>
       </properties>
+    </profile>
+
+    <profile>
+      <id>maven-central-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${plugin.gpg.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <keyname>java-native</keyname>
+              <passphraseServerId>gpg.passphrase</passphraseServerId>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>${plugin.nexus-staging.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>


### PR DESCRIPTION
Currently there is no straight-forward way of doing deployment to Maven Central as it involves several manual steps when setting up the environment:
- setting up right Java version to ensure the project is usable for the majority of end users
- setting up published PGP key required for signing artifacts before they are accepted by Maven Central
- setting up OSSRH credentials for actual artifact deployment and release

The idea behind this PR is to automate the process using Github actions and to take advantage of the repository secrets to store credentials and keys. I know the project already uses travis-ci, and it would be quite straight-forward to achieve the same goals using this tool, but moving to github actions has the benefit of keeping critical parts of the flow reusable by forks and simplifies access management.

What this change does NOT do, but perhaps we want another PR to cover:
- Ensure the native libraries are build using the same revision for all plaforms
- Update versions in pom.xml
- Tag the exact revision sent to central
- Automatically perform release to Github Releases

If this is to be accepted, the repository maintainer needs to create 4 repository secrets referenced in the workflow file. After that deploying to Maven Central is the question of pressing a button under Actions tab.
