### PR TITLE
Automatic release to Maven central 

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -1,0 +1,42 @@
+name: Release New Version
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version'
+        required: false
+
+env:
+  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  JAVA_TOOL_OPTIONS: -Duser.name=io.github.java-native
+  GITHUB_BOT_NAME: github-actions
+  GITHUB_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+jobs:
+  maven-central-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git config --global user.email "${GITHUB_BOT_EMAIL}"
+      - run: git config --global user.name "${GITHUB_BOT_NAME}"
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: temurin
+          server-id: ossrh
+          server-username: OSSRH_TOKEN_USERNAME
+          server-password: OSSRH_TOKEN_PASSWORD
+          gpg-private-key: ${{ secrets.JAVA_NATIVE_PGP_KEY }}
+          gpg-passphrase: PGP_KEY_PASSPHRASE
+      - name: Set release version if provided as input
+        if: github.event.inputs.releaseVersion != ''
+        run: echo "VERSIONS=-DreleaseVersion=${{ github.event.inputs.releaseVersion }}" >> $GITHUB_ENV
+      - name: Publish artifacts to Maven Central
+        run: mvn -B release:prepare release:perform -P package,maven-central-release ${VERSIONS}
+        env:
+          OSSRH_TOKEN_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}
+          OSSRH_TOKEN_PASSWORD: ${{ secrets.OSSRH_TOKEN_PASSWORD }}
+          PGP_KEY_PASSPHRASE: ${{ secrets.JAVA_NATIVE_PGP_KEY_PASSPHRASE }}
+      - name: Push changes back to repo
+        run: git push && git push --tags --force

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <connection>scm:git:https://github.com/java-native/jssc.git</connection>
     <developerConnection>scm:git:git@github.com:java-native/jssc.git</developerConnection>
     <url>https://github.com/java-native/jssc</url>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>
@@ -63,10 +64,13 @@
     <plugin.build-helper-maven-version>3.2.0</plugin.build-helper-maven-version>
     <plugin.compiler.version>3.8.0</plugin.compiler.version>
     <plugin.enforcer.version>3.0.0-M3</plugin.enforcer.version>
+    <plugin.gpg.version>3.0.1</plugin.gpg.version>
     <plugin.jar.version>3.1.1</plugin.jar.version>
     <plugin.javadoc.version>3.1.1</plugin.javadoc.version>
     <plugin.nar.version>3.6.0</plugin.nar.version>
+    <plugin.nexus-staging.version>1.6.7</plugin.nexus-staging.version>
     <plugin.osmaven.version>1.7.0</plugin.osmaven.version>
+    <plugin.release.version>3.0.0-M4</plugin.release.version>
     <plugin.signature.version>1.1</plugin.signature.version>
     <plugin.source.version>3.0.1</plugin.source.version>
     <plugin.surfire.version>3.0.0-M4</plugin.surfire.version>
@@ -447,7 +451,7 @@
              <execution>
                <id>attach-sources</id>
                <goals>
-                 <goal>jar</goal>
+                 <goal>jar-no-fork</goal>
                </goals>
              </execution>
            </executions>
@@ -572,6 +576,57 @@
         <os.target.arch>arm_32</os.target.arch>
         <os.target.bitness>32</os.target.bitness>
       </properties>
+    </profile>
+
+    <profile>
+      <id>maven-central-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${plugin.gpg.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <keyname>java-native</keyname>
+              <passphraseServerId>gpg.passphrase</passphraseServerId>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>${plugin.release.version}</version>
+            <configuration>
+              <tagNameFormat>v@{project.version}</tagNameFormat>
+              <pushChanges>false</pushChanges>
+              <localCheckout>true</localCheckout>
+              <goals>deploy</goals>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>${plugin.nexus-staging.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>


### PR DESCRIPTION
(Reopen of wrongly closed #100) -- revised

Currently there is no straight-forward way of doing deployment to Maven Central as it involves several manual steps when setting up the environment:
- setting up right Java version to ensure the project is usable for the majority of end users
- setting up published PGP key required for signing artifacts before they are accepted by Maven Central
- setting up OSSRH credentials for actual artifact deployment and release

The idea behind this PR is to automate the process using Github actions and to take advantage of the repository secrets to store credentials and keys. 

### Goals:
- [x] Reproducible, transparent and auditable build mechanism for Maven Central deployment. 
- [x] Everything requrired for a Maven Central deployment is contained within this GitHub repository and nowhere else (not on external CI, not in maintainers PC). 
- [x] Repository secrets set up
- [x] pom.xml version is bumped automatically; release is always done from non-snapshot version, and next snapshot version is set in the source after (automatic commits)
- [x] Exact git revision from which the release build was created is appropriately tagged in the repository (no rebase on merge, etc)
- [x] Deployment can be triggered with GitHub UI (by project collaborators)

### Non-goals (pending separate PRs)
- Building native libraries. Native libraries are part of the source in this project, so it is assumed they have all been commited before triggering the build. Only pom.xml is updated.
- Repository maintenance: wiki or readme are not part of the bundle deployed to Maven Central, and are not touched.
- Github Release. Creating or describing Github release or building fat jar that is normally published there are not done - has to be done from a tagged commit manually.

If this is to be accepted, the repository maintainer (which is not me) needs to create 4 repository secrets referenced in the workflow file: token login + password to https://oss.sonatype.org/ with permission in `io.github.java-native` and published GPG key + passphrase for signing the artifacts. 

After that deploying to Maven Central is the question of pressing a button under Actions tab (and optionally - confirming the release in Nexus, but we may include it in the workflow - opinions?)