### PR TITLE
Fix all javadoc warnings

### DIFF
--- a/src/main/cpp/_nix_based/jssc.cpp
+++ b/src/main/cpp/_nix_based/jssc.cpp
@@ -628,7 +628,7 @@ JNIEXPORT jint JNICALL Java_jssc_SerialNativeInterface_getFlowControlMode
 
 /* OK */
 /*
- * Send break for setted duration
+ * Send break for set duration
  */
 JNIEXPORT jboolean JNICALL Java_jssc_SerialNativeInterface_sendBreak
   (JNIEnv *, jobject, jlong portHandle, jint duration){

--- a/src/main/cpp/windows/jssc.cpp
+++ b/src/main/cpp/windows/jssc.cpp
@@ -136,7 +136,7 @@ JNIEXPORT jboolean JNICALL Java_jssc_SerialNativeInterface_setParams
 
         if(SetCommState(hComm, dcb)){
 
-        	//since 2.1.0 -> previously set timeouts by another application should be cleared
+        	//since 2.1.0 -> timeouts set previously by another application should be cleared
         	COMMTIMEOUTS *lpCommTimeouts = new COMMTIMEOUTS();
         	lpCommTimeouts->ReadIntervalTimeout = 0;
         	lpCommTimeouts->ReadTotalTimeoutConstant = 0;

--- a/src/main/cpp/windows/jssc.cpp
+++ b/src/main/cpp/windows/jssc.cpp
@@ -136,7 +136,7 @@ JNIEXPORT jboolean JNICALL Java_jssc_SerialNativeInterface_setParams
 
         if(SetCommState(hComm, dcb)){
 
-        	//since 2.1.0 -> previously setted timeouts by another application should be cleared
+        	//since 2.1.0 -> previously set timeouts by another application should be cleared
         	COMMTIMEOUTS *lpCommTimeouts = new COMMTIMEOUTS();
         	lpCommTimeouts->ReadIntervalTimeout = 0;
         	lpCommTimeouts->ReadTotalTimeoutConstant = 0;
@@ -392,7 +392,7 @@ JNIEXPORT jint JNICALL Java_jssc_SerialNativeInterface_getFlowControlMode
 }
 
 /*
- * Send break for setted duration
+ * Send break for set duration
  *
  * since 0.8
  */

--- a/src/main/java/jssc/SerialNativeInterface.java
+++ b/src/main/java/jssc/SerialNativeInterface.java
@@ -37,43 +37,71 @@ public class SerialNativeInterface {
     private static final String libVersion = "2.9";
     private static final String libMinorSuffix = "1"; //since 0.9.0
 
+    /** Linux **/
     public static final int OS_LINUX = 0;
+    /** Windows **/
     public static final int OS_WINDOWS = 1;
+    /** Solaris **/
     public static final int OS_SOLARIS = 2;//since 0.9.0
+    /** MacOS **/
     public static final int OS_MAC_OS_X = 3;//since 0.9.0
-
-    private static int osType = -1;
+    /** Unknown **/
+    public static final int OS_UNKNOWN = -1;//since 0.9.0
 
     /**
+     * Port is busy
+     *
      * @since 2.3.0
      */
     public static final long ERR_PORT_BUSY = -1;
     /**
+     * Port is not found
+     *
      * @since 2.3.0
      */
     public static final long ERR_PORT_NOT_FOUND = -2;
     /**
+     * Insufficient permissions to access port
+     *
      * @since 2.3.0
      */
     public static final long ERR_PERMISSION_DENIED = -3;
     /**
+     * Serial port handle is incorrect
+     *
      * @since 2.3.0
      */
     public static final long ERR_INCORRECT_SERIAL_PORT = -4;
 
     /**
+     * Disable exclusive lock for serial port
+     *
+     * Usage:
+     * <code>System.setProperty("jssc_no_tiocexcl", "true");</code>
+     *
      * @since 2.6.0
      */
     public static final String PROPERTY_JSSC_NO_TIOCEXCL = "JSSC_NO_TIOCEXCL";
     /**
+     * Ignore bytes with framing error or parity error
+     *
+     * Usage:
+     * <code>System.setProperty("jssc_ignpar", "true");</code>
+     *
      * @since 2.6.0
      */
     public static final String PROPERTY_JSSC_IGNPAR = "JSSC_IGNPAR";
     /**
+     * Mark bytes with parity error or framing error
+     *
+     * Usage:
+     * <code>System.setProperty("jssc_iparmrk", "true");</code>
+     *
      * @since 2.6.0
      */
     public static final String PROPERTY_JSSC_PARMRK = "JSSC_PARMRK";
 
+    private static int osType;
     static {
         String osName = System.getProperty("os.name");
         if(osName.equals("Linux"))
@@ -84,6 +112,8 @@ public class SerialNativeInterface {
             osType = OS_SOLARIS;
         else if(osName.equals("Mac OS X") || osName.equals("Darwin"))
             osType = OS_MAC_OS_X;
+        else
+            osType = OS_UNKNOWN;
         try {
             NativeLoader.loadLibrary("jssc");
         } catch (IOException ioException) {
@@ -92,7 +122,10 @@ public class SerialNativeInterface {
     }
 
     /**
-     * Get OS type (OS_LINUX || OS_WINDOWS || OS_SOLARIS)
+     * Get OS type
+     *
+     * @return <code>OS_LINUX</code>, <code>OS_WINDOWS</code>, <code>OS_SOLARIS</code>,<code>OS_MACOS</code>
+     * or <code>-1</code> if unknown.
      * 
      * @since 0.8
      */
@@ -101,7 +134,9 @@ public class SerialNativeInterface {
     }
 
     /**
-     * Get jSSC version. The version of library is <b>Base Version</b> + <b>Minor Suffix</b>
+     * Get library version
+     *
+     * @return Full library version in "major.minor.patch" format.
      *
      * @since 0.8
      */
@@ -110,27 +145,35 @@ public class SerialNativeInterface {
     }
 
     /**
-     * Get jSSC Base Version
+     * Get library base Version
+     *
+     * @return Library base version in "major.minor" format.   Was previously used for library versioning caching
+     * but is no longer used by the project.
      *
      * @since 0.9.0
      */
+    @Deprecated
     public static String getLibraryBaseVersion() {
         return libVersion;
     }
 
     /**
-     * Get jSSC minor suffix. For example in version 0.8.1 - <b>1</b> is a minor suffix
+     * Get library patch version
+     *
+     * @return Library patch version only (e.g. only "patch" from "major.minor.patch").  Was previously used for
+     * library versioning caching but is no longer used by the project.
      *
      * @since 0.9.0
      */
+    @Deprecated
     public static String getLibraryMinorSuffix() {
         return libMinorSuffix;
     }
 
     /**
-     * Get jSSC native library version
+     * Get native library version
      *
-     * @return native lib version (for jSSC-2.8.0 should be 2.8 for example)
+     * @return Full native library version in "major.minor.patch" format.
      *
      * @since 2.8.0
      */
@@ -280,7 +323,7 @@ public class SerialNativeInterface {
      *
      * @param handle handle of opened port
      *
-     * @return Mask of setted flow control mode
+     * @return Mask of set flow control mode
      *
      * @since 0.8
      */
@@ -307,7 +350,7 @@ public class SerialNativeInterface {
     public native int[] getLinesStatus(long handle);
 
     /**
-     * Send Break singnal for setted duration
+     * Send Break signal for set duration
      * 
      * @param handle handle of opened port
      * @param duration duration of Break signal

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -32,6 +32,7 @@ import java.nio.charset.Charset;
  *
  * @author scream3r
  */
+@SuppressWarnings("unused")
 public class SerialPort {
 
     private SerialNativeInterface serialInterface;
@@ -45,74 +46,120 @@ public class SerialPort {
     //since 2.2.0 ->
     private Method methodErrorOccurred = null;
     //<- since 2.2.0
-    
+
+    /** Baud rate 110 symbols/second **/
     public static final int BAUDRATE_110 = 110;
+    /** Baud rate 300 symbols/second **/
     public static final int BAUDRATE_300 = 300;
+    /** Baud rate 600 symbols/second **/
     public static final int BAUDRATE_600 = 600;
+    /** Baud rate 1200 symbols/second **/
     public static final int BAUDRATE_1200 = 1200;
+    /** Baud rate 2400 symbols/second **/
     public static final int BAUDRATE_2400 = 2400;
+    /** Baud rate 4800 symbols/second **/
     public static final int BAUDRATE_4800 = 4800;
+    /** Baud rate 9600 symbols/second **/
     public static final int BAUDRATE_9600 = 9600;
+    /** Baud rate 14400 symbols/second **/
     public static final int BAUDRATE_14400 = 14400;
+    /** Baud rate 19200 symbols/second **/
     public static final int BAUDRATE_19200 = 19200;
+    /** Baud rate 38400 symbols/second **/
     public static final int BAUDRATE_38400 = 38400;
+    /** Baud rate 57600 symbols/second **/
     public static final int BAUDRATE_57600 = 57600;
+    /** Baud rate 115200 symbols/second **/
     public static final int BAUDRATE_115200 = 115200;
+    /** Baud rate 128000 symbols/second **/
     public static final int BAUDRATE_128000 = 128000;
+    /** Baud rate 256000 symbols/second **/
     public static final int BAUDRATE_256000 = 256000;
 
-
+    /** Five (5) data bits per byte **/
     public static final int DATABITS_5 = 5;
+    /** Six (6) data bits per byte **/
     public static final int DATABITS_6 = 6;
+    /** Seven (7) data bits per byte **/
     public static final int DATABITS_7 = 7;
+    /** Eight (8) data bits per byte **/
     public static final int DATABITS_8 = 8;
-    
 
+    /** One (1) stop bits per byte **/
     public static final int STOPBITS_1 = 1;
+    /** Two (2) stop bits per byte **/
     public static final int STOPBITS_2 = 2;
+    /** One and a half (1.5) stop bits per byte **/
     public static final int STOPBITS_1_5 = 3;
-    
 
+    /** Do not send a parity bit **/
     public static final int PARITY_NONE = 0;
+    /** Use a very basic checksum: Send an additional bit to report if odd number of data bits **/
     public static final int PARITY_ODD = 1;
+    /** Use a very basic checksum: Send an additional bit to report if even number of data bits **/
     public static final int PARITY_EVEN = 2;
+    /** Use a very basic checksum: Send a parity bit to indicate "mark signal" condition (rarely used) **/
     public static final int PARITY_MARK = 3;
+    /** Use a very basic checksum: Send a parity bit to indicate "space signal" condition (rarely used) **/
     public static final int PARITY_SPACE = 4;
-     
 
+
+    /** Receive "abort" status code **/
     public static final int PURGE_RXABORT = 0x0002;
+    /** Receive "clear" status code **/
     public static final int PURGE_RXCLEAR = 0x0008;
+    /** Transfer "abort" status code **/
     public static final int PURGE_TXABORT = 0x0001;
+    /** Transfer "clear" status code **/
     public static final int PURGE_TXCLEAR = 0x0004;
 
 
+    /** Receive character flag **/
     public static final int MASK_RXCHAR = 1;
+    /** Receive flag **/
     public static final int MASK_RXFLAG = 2;
+    /** Receive empty flag **/
     public static final int MASK_TXEMPTY = 4;
+    /** CTS (clear to send) mask **/
     public static final int MASK_CTS = 8;
+    /** DSR (data set to ready) flag **/
     public static final int MASK_DSR = 16;
+    /** RLSD (Receive Line Signal Detected) flag **/
     public static final int MASK_RLSD = 32;
+    /** Break (reset a communications line or change the operating mode) flag **/
     public static final int MASK_BREAK = 64;
+    /** Error flag **/
     public static final int MASK_ERR = 128;
-    public static final int MASK_RING = 256;
+    /** State of RING line (0 - OFF, 1 - ON) **/
+     public static final int MASK_RING = 256;
 
 
     //since 0.8 ->
+    /** Disable flow control **/
     public static final int FLOWCONTROL_NONE = 0;
+    /** Legacy hardware control: RTS/CTS (request to send/clear to send) flow control on input **/
     public static final int FLOWCONTROL_RTSCTS_IN = 1;
+    /** Legacy hardware control: RTS/CTS (request to send/clear to send) flow control on output **/
     public static final int FLOWCONTROL_RTSCTS_OUT = 2;
+    /** Software flow control: XON/XOFF flow control on input **/
     public static final int FLOWCONTROL_XONXOFF_IN = 4;
+    /** Software flow control: XON/XOFF flow control on output **/
     public static final int FLOWCONTROL_XONXOFF_OUT = 8;
     //<- since 0.8
 
     //since 0.8 ->
+    /** Indicates faulty data or frame **/
     public static final int ERROR_FRAME = 0x0008;
+    /** Overrun error; receiver hardware unable to handle receive data **/
     public static final int ERROR_OVERRUN = 0x0002;
+    /** Parity/check bit error **/
     public static final int ERROR_PARITY = 0x0004;
     //<- since 0.8
 
     //since 2.6.0 ->
+    /** Ignore bytes with framing error or parity error **/
     private static final int PARAMS_FLAG_IGNPAR = 1;
+    /** Mark bytes with parity error or framing error **/
     private static final int PARAMS_FLAG_PARMRK = 2;
     //<- since 2.6.0
 

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -163,6 +163,11 @@ public class SerialPort {
     private static final int PARAMS_FLAG_PARMRK = 2;
     //<- since 2.6.0
 
+    /**
+     * Construct a serial port object with the specified <code>portName</code>
+     *
+     * @param portName Name of the port, e.g. <code>COM1</code>, <code>/dev/tty.FOO</code>, etc.
+     */
     public SerialPort(String portName) {
         this.portName = portName;
         serialInterface = new SerialNativeInterface();
@@ -194,7 +199,7 @@ public class SerialPort {
      *
      * @return If the operation is successfully completed, the method returns true
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean openPort() throws SerialPortException {
         if(portOpened){
@@ -234,7 +239,7 @@ public class SerialPort {
      *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean setParams(int baudRate, int dataBits, int stopBits, int parity) throws SerialPortException {
         return setParams(baudRate, dataBits, stopBits, parity, true, true);
@@ -252,7 +257,7 @@ public class SerialPort {
      *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -281,9 +286,11 @@ public class SerialPort {
      * parameter <b>"PURGE_RXCLEAR | PURGE_TXCLEAR"</b>.
      * <br><b>Note: </b>some devices or drivers may not support this function
      *
+     * @param flags One or more <code>SerialPort.PURGE_*</code> flag
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false. 
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean purgePort(int flags) throws SerialPortException {
         checkPortOpened("purgePort()");
@@ -303,10 +310,12 @@ public class SerialPort {
      * Sent parameter "mask" is additive value, so addition of flags is allowed.
      * For example if messages about data receipt and CTS and DSR status changing
      * shall be received, it is required to set the mask - <b>"MASK_RXCHAR | MASK_CTS | MASK_DSR"</b>
+     *
+     * @param mask One or more <code>SerialPort.MASK_*</code> value
      * 
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean setEventsMask(int mask) throws SerialPortException {
         checkPortOpened("setEventsMask()");
@@ -340,7 +349,7 @@ public class SerialPort {
      * 
      * @return Method returns events mask as int type variable. This variable is an additive value
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public int getEventsMask() throws SerialPortException {
         checkPortOpened("getEventsMask()");
@@ -364,9 +373,11 @@ public class SerialPort {
     /**
      * Change RTS line state. Set "true" for switching ON and "false" for switching OFF RTS line
      *
+     * @param enabled on/off flag
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean setRTS(boolean enabled) throws SerialPortException {
         checkPortOpened("setRTS()");
@@ -376,9 +387,11 @@ public class SerialPort {
     /**
      * Change DTR line state. Set "true" for switching ON and "false" for switching OFF DTR line
      *
+     * @param enabled on/off flag
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean setDTR(boolean enabled) throws SerialPortException {
         checkPortOpened("setDTR()");
@@ -388,9 +401,11 @@ public class SerialPort {
     /**
      * Write byte array to port
      *
+     * @param buffer <code>byte[]</code> array to write
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      * 
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean writeBytes(byte[] buffer) throws SerialPortException {
         checkPortOpened("writeBytes()");
@@ -400,9 +415,11 @@ public class SerialPort {
     /**
      * Write single byte to port
      *
+     * @param singleByte single <code>byte</code> value to write
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -414,9 +431,11 @@ public class SerialPort {
     /**
      * Write String to port
      *
+     * @param string <code>String</code> value to write
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -428,9 +447,12 @@ public class SerialPort {
     /**
      * Write String to port
      *
+     * @param string <code>String</code> value to write
+     * @param charsetName valid <code>Charset</code> name, e.g. <code>"UTF-8"</code>
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
+     * @throws UnsupportedEncodingException if encoding exception occurred
      *
      * @since 2.8.0
      */
@@ -442,9 +464,11 @@ public class SerialPort {
     /**
      * Write int value (in range from 0 to 255 (0x00 - 0xFF)) to port
      *
+     * @param singleInt single <code>int</code> value to write
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -456,9 +480,11 @@ public class SerialPort {
     /**
      * Write int array (in range from 0 to 255 (0x00 - 0xFF)) to port
      *
+     * @param buffer <code>int[]</code> array to write
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -478,7 +504,7 @@ public class SerialPort {
      * 
      * @return byte array with "byteCount" length
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public byte[] readBytes(int byteCount) throws SerialPortException {
         checkPortOpened("readBytes()");
@@ -492,7 +518,7 @@ public class SerialPort {
      *
      * @return byte array with "byteCount" length converted to String
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -508,7 +534,7 @@ public class SerialPort {
      *
      * @return byte array with "byteCount" length converted to Hexadecimal String
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -518,13 +544,14 @@ public class SerialPort {
     }
 
     /**
-     * Read Hex string from port with setted separator (example if separator is "::": FF::0A::FF)
+     * Read Hex string from port with set separator (example if separator is "::": FF::0A::FF)
      *
      * @param byteCount count of bytes for reading
+     * @param separator the hex string separator, e.g. "::", etc
      *
      * @return byte array with "byteCount" length converted to Hexadecimal String
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -550,7 +577,7 @@ public class SerialPort {
      * 
      * @return String array with "byteCount" length and Hexadecimal String values
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -575,7 +602,7 @@ public class SerialPort {
      *
      * @return int array with values in range from 0 to 255
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -611,7 +638,7 @@ public class SerialPort {
             }
         }
         if(timeIsOut){
-            throw new SerialPortTimeoutException(portName, methodName, timeout);
+            throw new SerialPortTimeoutException(this, methodName, timeout);
         }
     }
 
@@ -623,8 +650,8 @@ public class SerialPort {
      *
      * @return byte array with "byteCount" length
      *
-     * @throws SerialPortException
-     * @throws SerialPortTimeoutException
+     * @throws SerialPortException if exception occurred
+     * @throws SerialPortTimeoutException if timeout exception occurred
      *
      * @since 2.0
      */
@@ -642,8 +669,8 @@ public class SerialPort {
      *
      * @return byte array with "byteCount" length converted to String
      *
-     * @throws SerialPortException
-     * @throws SerialPortTimeoutException
+     * @throws SerialPortException if exception occurred
+     * @throws SerialPortTimeoutException if timeout exception occurred
      *
      * @since 2.0
      */
@@ -661,8 +688,8 @@ public class SerialPort {
      *
      * @return byte array with "byteCount" length converted to Hexadecimal String
      *
-     * @throws SerialPortException
-     * @throws SerialPortTimeoutException
+     * @throws SerialPortException if exception occurred
+     * @throws SerialPortTimeoutException if timeout exception occurred
      *
      * @since 2.0
      */
@@ -673,15 +700,16 @@ public class SerialPort {
     }
 
     /**
-     * Read Hex string from port with setted separator (example if separator is "::": FF::0A::FF)
+     * Read Hex string from port with set separator (example if separator is "::": FF::0A::FF)
      *
      * @param byteCount count of bytes for reading
+     * @param separator the hex string separator, e.g. "::", etc
      * @param timeout timeout in milliseconds
      *
      * @return byte array with "byteCount" length converted to Hexadecimal String
      *
-     * @throws SerialPortException
-     * @throws SerialPortTimeoutException
+     * @throws SerialPortException if exception occurred
+     * @throws SerialPortTimeoutException if timeout exception occurred
      *
      * @since 2.0
      */
@@ -699,8 +727,8 @@ public class SerialPort {
      *
      * @return String array with "byteCount" length and Hexadecimal String values
      *
-     * @throws SerialPortException
-     * @throws SerialPortTimeoutException
+     * @throws SerialPortException if exception occurred
+     * @throws SerialPortTimeoutException if timeout exception occurred
      *
      * @since 2.0
      */
@@ -718,8 +746,8 @@ public class SerialPort {
      *
      * @return int array with values in range from 0 to 255
      *
-     * @throws SerialPortException
-     * @throws SerialPortTimeoutException
+     * @throws SerialPortException if exception occurred
+     * @throws SerialPortTimeoutException if timeout exception occurred
      *
      * @since 2.0
      */
@@ -734,7 +762,7 @@ public class SerialPort {
      *
      * @return If input buffer is empty <b>null</b> will be returned, else byte array with all data from port
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -752,7 +780,7 @@ public class SerialPort {
      *
      * @return If input buffer is empty <b>null</b> will be returned, else byte array with all data from port converted to String
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -770,7 +798,7 @@ public class SerialPort {
      *
      * @return If input buffer is empty <b>null</b> will be returned, else byte array with all data from port converted to Hex String
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -784,11 +812,13 @@ public class SerialPort {
     }
 
     /**
-     * Read all available bytes from port like a Hex String with setted separator
+     * Read all available bytes from port like a Hex String with set separator
+     *
+     * @param separator the hex string separator, e.g. "::", etc
      *
      * @return If input buffer is empty <b>null</b> will be returned, else byte array with all data from port converted to Hex String
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -806,7 +836,7 @@ public class SerialPort {
      *
      * @return If input buffer is empty <b>null</b> will be returned, else byte array with all data from port converted to Hex String array
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -824,7 +854,7 @@ public class SerialPort {
      *
      * @return If input buffer is empty <b>null</b> will be returned, else byte array with all data from port converted to int array
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -842,7 +872,7 @@ public class SerialPort {
      *
      * @return Count of bytes in input buffer or -1 if error occured
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -856,7 +886,7 @@ public class SerialPort {
      *
      * @return Count of bytes in output buffer or -1 if error occured
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -869,9 +899,11 @@ public class SerialPort {
      * Set flow control mode. For required mode use variables with prefix <b>"FLOWCONTROL_"</b>.
      * Example of hardware flow control mode(RTS/CTS): setFlowControlMode(FLOWCONTROL_RTSCTS_IN | FLOWCONTROL_RTSCTS_OUT);
      *
+     * @param mask mask of flow control mode
+     *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -883,9 +915,9 @@ public class SerialPort {
     /**
      * Get flow control mode
      *
-     * @return Mask of setted flow control mode
+     * @return Mask of set flow control mode
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -895,13 +927,13 @@ public class SerialPort {
     }
 
     /**
-     * Send Break singnal for setted duration
+     * Send Break singnal for set duration
      *
      * @param duration duration of Break signal
      *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      * 
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      *
      * @since 0.8
      */
@@ -919,7 +951,7 @@ public class SerialPort {
      *
      * @param methodName method name
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     private void checkPortOpened(String methodName) throws SerialPortException {
         if(!portOpened){
@@ -936,7 +968,7 @@ public class SerialPort {
      * <br><b>element 2</b> - <b>RING</b> line state
      * <br><b>element 3</b> - <b>RLSD</b> line state
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public int[] getLinesStatus() throws SerialPortException {
         checkPortOpened("getLinesStatus()");
@@ -948,7 +980,7 @@ public class SerialPort {
      *
      * @return If line is active, method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean isCTS() throws SerialPortException {
         checkPortOpened("isCTS()");
@@ -965,7 +997,7 @@ public class SerialPort {
      *
      * @return If line is active, method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean isDSR() throws SerialPortException {
         checkPortOpened("isDSR()");
@@ -982,7 +1014,7 @@ public class SerialPort {
      * 
      * @return If line is active, method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean isRING() throws SerialPortException {
         checkPortOpened("isRING()");
@@ -999,7 +1031,7 @@ public class SerialPort {
      * 
      * @return If line is active, method returns true, otherwise false
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean isRLSD() throws SerialPortException {
         checkPortOpened("isRLSD()");
@@ -1017,7 +1049,9 @@ public class SerialPort {
      * be in charge for handling of occurred events. This method will independently
      * set the mask in <b>"MASK_RXCHAR"</b> state if it was not set beforehand
      *
-     * @throws SerialPortException
+     * @param listener Event Listener of type <code>SerialPortListener</code>
+     *
+     * @throws SerialPortException if exception occurred
      */
     public void addEventListener(SerialPortEventListener listener) throws SerialPortException {
         addEventListener(listener, MASK_RXCHAR, false);
@@ -1029,9 +1063,12 @@ public class SerialPort {
      * charge for handling of occurred events. Also events mask shall be sent to
      * this method, to do it use variables with prefix <b>"MASK_"</b> for example <b>"MASK_RXCHAR"</b>
      *
+     * @param listener Event Listener of type <code>SerialPortListener</code>
+     * @param mask <code>SerialPort.MASK_*</code> representing the event mask to listen upon
+     *
      * @see #setEventsMask(int) setEventsMask(int mask)
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public void addEventListener(SerialPortEventListener listener, int mask) throws SerialPortException {
         addEventListener(listener, mask, true);
@@ -1042,14 +1079,18 @@ public class SerialPort {
      * to the method. This object shall be properly described, as it will be in
      * charge for handling of occurred events. Also events mask shall be sent to
      * this method, to do it use variables with prefix <b>"MASK_"</b> for example <b>"MASK_RXCHAR"</b>. If
-     * <b>overwriteMask == true</b> and mask has been already assigned it value will be rewrited by <b>mask</b>
+     * <b>overwriteMask == true</b> and mask has been already assigned it value will be rewritten by <b>mask</b>
      * value, if <b>overwriteMask == false</b> and mask has been already assigned the new <b>mask</b> value will be ignored,
      * if there is no assigned mask to this serial port the <b>mask</b> value will be used for setting it up in spite of
      * <b>overwriteMask</b> value
      *
+     * @param listener Event Listener of type <code>SerialPortListener</code>
+     * @param mask <code>SerialPort.MASK_*</code> representing the event mask to listen upon
+     * @param overwriteMask overwrite <code>mask</code> if already assigned
+     *
      * @see #setEventsMask(int) setEventsMask(int mask)
      *
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     private void addEventListener(SerialPortEventListener listener, int mask, boolean overwriteMask) throws SerialPortException {
         checkPortOpened("addEventListener()");
@@ -1101,7 +1142,7 @@ public class SerialPort {
      *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      * 
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean removeEventListener() throws SerialPortException {
         checkPortOpened("removeEventListener()");
@@ -1130,7 +1171,7 @@ public class SerialPort {
      *
      * @return If the operation is successfully completed, the method returns true, otherwise false
      * 
-     * @throws SerialPortException
+     * @throws SerialPortException if exception occurred
      */
     public boolean closePort() throws SerialPortException {
         checkPortOpened("closePort()");

--- a/src/main/java/jssc/SerialPortEvent.java
+++ b/src/main/java/jssc/SerialPortEvent.java
@@ -74,12 +74,31 @@ public class SerialPortEvent {
     @Deprecated
     public static final int RING = SerialPort.MASK_RING;
 
+    /**
+     * Constructs a SerialPortEvent representing a port, event type and event value.
+     *
+     * @param port <code>SerialPort</code> object which the event occurred
+     * @param eventType Can be any value from <code>SerialPort.MASK_*</code> or <code>LinuxEventThread.INTERRUPT_*</code>
+     * @param eventValue Event value which changes context depending on <code>getEventType()</code>
+     *
+     * @see #getEventType()
+     */
     public SerialPortEvent(SerialPort port, int eventType, int eventValue){
         this.port = port;
         this.eventType = eventType;
         this.eventValue = eventValue;
     }
 
+    /**
+     * Constructs a SerialPortEvent representing a port, event type and event value.
+     * Deprecated: Use <code>SerialPortEvent(SerialPort, int, int)</code> instead.
+     *
+     * @param portName port which the event occurred
+     * @param eventType Can be any value from <code>SerialPort.MASK_*</code> or <code>LinuxEventThread.INTERRUPT_*</code>
+     * @param eventValue Event value which changes context depending on <code>getEventType()</code>
+     *
+     * @see #SerialPortEvent(SerialPort, int, int)
+     */
     @Deprecated
     public SerialPortEvent(String portName, int eventType, int eventValue){
         this.portName = portName;
@@ -89,6 +108,8 @@ public class SerialPortEvent {
 
     /**
      * Getting the port that set off this event
+     *
+     * @return The <code>SerialPort</code> object the event occurred on
      */
     public SerialPort getPort(){
         return port;
@@ -96,6 +117,8 @@ public class SerialPortEvent {
 
     /**
      * Getting port name which sent the event
+     *
+     * @return The port name the event occurred on
      */
     @Deprecated
     public String getPortName() {
@@ -104,7 +127,10 @@ public class SerialPortEvent {
 
     /**
      * Getting event type
+     *
+     * @return The <code>SerialPort.MASK_*</code> event mask
      */
+    @SuppressWarnings("unused")
     public int getEventType() {
         return eventType;
     }
@@ -122,70 +148,96 @@ public class SerialPortEvent {
      * <br><b>BREAK</b> - 0
      * <br><b>RING</b> - state of RING line (0 - OFF, 1 - ON)
      * <br><b>ERR</b> - mask of errors
+     * @return Event value which changes context depending on <code>getEventType()</code> (see listing)
      */
+    @SuppressWarnings("unused")
     public int getEventValue() {
         return eventValue;
     }
 
     /**
-     * Method returns true if event of type <b>"RXCHAR"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_RXCHAR</code>
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isRXCHAR() {
         return eventType == SerialPort.MASK_RXCHAR;
     }
 
     /**
-     * Method returns true if event of type <b>"RXFLAG"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_RXFLAG</code>
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isRXFLAG() {
         return eventType == SerialPort.MASK_RXFLAG;
     }
 
     /**
-     * Method returns true if event of type <b>"TXEMPTY"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_TXEMPTY</code>
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isTXEMPTY() {
         return eventType == SerialPort.MASK_TXEMPTY;
     }
 
     /**
-     * Method returns true if event of type <b>"CTS"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_CTS</code>
+     *
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isCTS() {
         return eventType == SerialPort.MASK_CTS;
     }
 
     /**
-     * Method returns true if event of type <b>"DSR"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_DSR</code>
+     *
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isDSR() {
         return eventType == SerialPort.MASK_DSR;
     }
 
     /**
-     * Method returns true if event of type <b>"RLSD"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_RLSD</code>
+     *
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isRLSD() {
         return eventType == SerialPort.MASK_RLSD;
     }
 
     /**
-     * Method returns true if event of type <b>"BREAK"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_RLSD</code>
+     *
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isBREAK() {
-        return eventType == SerialPort.MASK_BREAK;
+        return eventType == SerialPort.MASK_RLSD;
     }
 
     /**
-     * Method returns true if event of type <b>"ERR"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_ERR</code>
+     *
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isERR() {
         return eventType == SerialPort.MASK_ERR;
     }
 
     /**
-     * Method returns true if event of type <b>"RING"</b> is received and otherwise false
+     * Convenience method to check if <code>getEventType()</code> is <code>SerialPort.MASK_RING</code>
+     *
+     * @return true or false
      */
+    @SuppressWarnings("unused")
     public boolean isRING() {
         return eventType == SerialPort.MASK_RING;
     }

--- a/src/main/java/jssc/SerialPortEvent.java
+++ b/src/main/java/jssc/SerialPortEvent.java
@@ -38,15 +38,41 @@ public class SerialPortEvent {
     @Deprecated
     private String portName;
 
-    public static final int RXCHAR = 1;
-    public static final int RXFLAG = 2;
-    public static final int TXEMPTY = 4;
-    public static final int CTS = 8;
-    public static final int DSR = 16;
-    public static final int RLSD = 32;
-    public static final int BREAK = 64;
-    public static final int ERR = 128;
-    public static final int RING = 256;
+    /** Deprecated: Use <code>SerialPort.MASK_RXCHAR</code> instead **/
+    @Deprecated
+    public static final int RXCHAR = SerialPort.MASK_RXCHAR;
+
+    /** Deprecated: Use <code>SerialPort.MASK_RXFLAG</code> instead **/
+    @Deprecated
+    public static final int RXFLAG = SerialPort.MASK_RXFLAG;
+
+    /** Deprecated: Use <code>SerialPort.MASK_TXEMPTY</code> instead **/
+    @Deprecated
+    public static final int TXEMPTY = SerialPort.MASK_TXEMPTY;
+
+    /** Deprecated: Use <code>SerialPort.MASK_CTS</code> instead **/
+    @Deprecated
+    public static final int CTS = SerialPort.MASK_CTS;
+
+    /** Deprecated: Use <code>SerialPort.MASK_DSR</code> instead **/
+    @Deprecated
+    public static final int DSR = SerialPort.MASK_DSR;
+
+    /** Deprecated: Use <code>SerialPort.MASK_RLSD</code> instead **/
+    @Deprecated
+    public static final int RLSD = SerialPort.MASK_RLSD;
+
+    /** Deprecated: Use <code>SerialPort.MASK_BREAK</code> instead **/
+    @Deprecated
+    public static final int BREAK = SerialPort.MASK_BREAK;
+
+    /** Deprecated: Use <code>SerialPort.MASK_ERR</code> instead **/
+    @Deprecated
+    public static final int ERR = SerialPort.MASK_ERR;
+
+    /** Deprecated: Use <code>SerialPort.MASK_RING</code> instead **/
+    @Deprecated
+    public static final int RING = SerialPort.MASK_RING;
 
     public SerialPortEvent(SerialPort port, int eventType, int eventValue){
         this.port = port;
@@ -105,62 +131,62 @@ public class SerialPortEvent {
      * Method returns true if event of type <b>"RXCHAR"</b> is received and otherwise false
      */
     public boolean isRXCHAR() {
-        return eventType == RXCHAR;
+        return eventType == SerialPort.MASK_RXCHAR;
     }
 
     /**
      * Method returns true if event of type <b>"RXFLAG"</b> is received and otherwise false
      */
     public boolean isRXFLAG() {
-        return eventType == RXFLAG;
+        return eventType == SerialPort.MASK_RXFLAG;
     }
 
     /**
      * Method returns true if event of type <b>"TXEMPTY"</b> is received and otherwise false
      */
     public boolean isTXEMPTY() {
-        return eventType == TXEMPTY;
+        return eventType == SerialPort.MASK_TXEMPTY;
     }
 
     /**
      * Method returns true if event of type <b>"CTS"</b> is received and otherwise false
      */
     public boolean isCTS() {
-        return eventType == CTS;
+        return eventType == SerialPort.MASK_CTS;
     }
 
     /**
      * Method returns true if event of type <b>"DSR"</b> is received and otherwise false
      */
     public boolean isDSR() {
-        return eventType == DSR;
+        return eventType == SerialPort.MASK_DSR;
     }
 
     /**
      * Method returns true if event of type <b>"RLSD"</b> is received and otherwise false
      */
     public boolean isRLSD() {
-        return eventType == RLSD;
+        return eventType == SerialPort.MASK_RLSD;
     }
 
     /**
      * Method returns true if event of type <b>"BREAK"</b> is received and otherwise false
      */
     public boolean isBREAK() {
-        return eventType == BREAK;
+        return eventType == SerialPort.MASK_BREAK;
     }
 
     /**
      * Method returns true if event of type <b>"ERR"</b> is received and otherwise false
      */
     public boolean isERR() {
-        return eventType == ERR;
+        return eventType == SerialPort.MASK_ERR;
     }
 
     /**
      * Method returns true if event of type <b>"RING"</b> is received and otherwise false
      */
     public boolean isRING() {
-        return eventType == RING;
+        return eventType == SerialPort.MASK_RING;
     }
 }

--- a/src/main/java/jssc/SerialPortEventListener.java
+++ b/src/main/java/jssc/SerialPortEventListener.java
@@ -29,6 +29,10 @@ package jssc;
  * @author scream3r
  */
 public interface SerialPortEventListener {
-
-    public abstract void serialEvent(SerialPortEvent serialPortEvent);
+    /**
+     * Called when an event fires
+     *
+     * @param serialPortEvent <code>SerialPortEvent</code> object containing port, event type and event data
+     */
+    void serialEvent(SerialPortEvent serialPortEvent);
 }

--- a/src/main/java/jssc/SerialPortException.java
+++ b/src/main/java/jssc/SerialPortException.java
@@ -30,11 +30,17 @@ package jssc;
  */
 public class SerialPortException extends Exception {
     final private static long serialVersionUID = 1L;
+    /** Port already opened **/
     final public static String TYPE_PORT_ALREADY_OPENED = "Port already opened";
+    /** Port not opened **/
     final public static String TYPE_PORT_NOT_OPENED = "Port not opened";
+    /** Can't set mask **/
     final public static String TYPE_CANT_SET_MASK = "Can't set mask";
+    /** Event listener already added **/
     final public static String TYPE_LISTENER_ALREADY_ADDED = "Event listener already added";
+    /** Event listener thread interrupted **/
     final public static String TYPE_LISTENER_THREAD_INTERRUPTED = "Event listener thread interrupted";
+    /** Can't remove event listener **/
     final public static String TYPE_CANT_REMOVE_LISTENER = "Can't remove event listener, because listener not added";
     /**
      * @since 0.8
@@ -61,10 +67,24 @@ public class SerialPortException extends Exception {
      */
     final public static String TYPE_INCORRECT_SERIAL_PORT = "Incorrect serial port";
 
+    /** Serial port object **/
     private SerialPort port;
+    /** Method name **/
     private String methodName;
+    /** Exception type **/
     private String exceptionType;
 
+    /** Port name **/
+    @Deprecated
+    private String portName;
+
+    /**
+     * Constructs a new <code>SerialPortException</code>
+     *
+     * @param port Port which the exception occurred on
+     * @param methodName Method name which the exception occurred on
+     * @param exceptionType Any <code>SerialPortException.TYPE_*</code>
+     */
     public SerialPortException(SerialPort port, String methodName, String exceptionType) {
         super("Port name - " + port.getPortName() + "; Method name - " + methodName + "; Exception type - " + exceptionType + ".");
         this.port = port;
@@ -72,9 +92,16 @@ public class SerialPortException extends Exception {
         this.exceptionType = exceptionType;
     }
 
-    @Deprecated
-    private String portName;
-
+    /**
+     * Constructs a new <code>SerialPortException</code>
+     * Deprecated: Use <code>SerialPortTimeoutException(SerialPort, String, String)</code> instead.
+     *
+     * @param portName Port which the exception occurred on
+     * @param methodName Method name which the exception occurred on
+     * @param exceptionType Any <code>SerialPortException.TYPE_*</code>
+     *
+     * @see #SerialPortException(SerialPort, String, String)
+     */
     @Deprecated
     public SerialPortException(String portName, String methodName, String exceptionType) {
         super("Port name - " + portName + "; Method name - " + methodName + "; Exception type - " + exceptionType + ".");
@@ -85,29 +112,42 @@ public class SerialPortException extends Exception {
 
     /**
      * Getting port name during operation with which the exception was called
+     * Deprecated: Use <code>getPort().getName()</code> instead.
+     *
+     * @return Port name
      */
     @Deprecated
     public String getPortName() {
-        return port.getPortName();
+        return port != null ? port.getPortName() : portName;
     }
 
     /**
-     * Getting the port which threw the exception
+     * Gets the <code>SerialPort</code> which threw the exception
+     *
+     * @return <code>SerialPort</code> object
      */
+    @SuppressWarnings("unused")
     public SerialPort getPort() {
         return port;
     }
 
     /**
-     * Getting method name during execution of which the exception was called
+     * Gets the method name during execution of which the exception was called
+     *
+     * @return Calling method name
      */
+    @SuppressWarnings("unused")
     public String getMethodName() {
         return methodName;
     }
 
     /**
      * Getting exception type
+     *
+     * @return a value from <code>SerialPortException.TYPE_*</code>
+     * or a custom <code>String</code> value if provided
      */
+    @SuppressWarnings("unused")
     public String getExceptionType() {
         return exceptionType;
     }

--- a/src/main/java/jssc/SerialPortList.java
+++ b/src/main/java/jssc/SerialPortList.java
@@ -70,7 +70,7 @@ public class SerialPortList {
         }
     }
 
-    //since 2.1.0 -> Fully rewrited port name comparator
+    //since 2.1.0 -> Fully rewritten port name comparator
     private static final Comparator<String> PORTNAMES_COMPARATOR = new Comparator<String>() {
 
         @Override

--- a/src/main/java/jssc/SerialPortTimeoutException.java
+++ b/src/main/java/jssc/SerialPortTimeoutException.java
@@ -30,10 +30,43 @@ package jssc;
  */
 public class SerialPortTimeoutException extends Exception {
     final private static long serialVersionUID = 1L;
-    private String portName;
+
+    /** Serial port object **/
+    private SerialPort port;
+    /** Method name **/
     private String methodName;
+    /** Timeout value **/
     private int timeoutValue;
 
+    /** Port name **/
+    @Deprecated
+    private String portName;
+
+    /**
+     * Constructs a new <code>SerialPortTimeoutException</code>
+     *
+     * @param port Port which the exception occurred on
+     * @param methodName Method name which the exception occurred on
+     * @param timeoutValue Timeout value which the exception occurred on
+     */
+    public SerialPortTimeoutException(SerialPort port, String methodName, int timeoutValue) {
+        super("Port name - " + port.getPortName() + "; Method name - " + methodName + "; Serial port operation timeout (" + timeoutValue + " ms).");
+        this.port = port;
+        this.methodName = methodName;
+        this.timeoutValue = timeoutValue;
+    }
+
+    /**
+     * Constructs a new <code>SerialPortTimeoutException</code>
+     * Deprecated: Use <code>SerialPortTimeoutException(SerialPort, String, int)</code> instead.
+     *
+     * @param portName Port name which the exception occurred on
+     * @param methodName Method name which the exception occurred on
+     * @param timeoutValue Timeout value which the exception occurred on
+     *
+     * @see #SerialPortTimeoutException(SerialPort, String, int)
+     */
+    @Deprecated
     public SerialPortTimeoutException(String portName, String methodName, int timeoutValue) {
         super("Port name - " + portName + "; Method name - " + methodName + "; Serial port operation timeout (" + timeoutValue + " ms).");
         this.portName = portName;
@@ -43,22 +76,42 @@ public class SerialPortTimeoutException extends Exception {
 
     /**
      * Getting port name during operation with which the exception was called
+     * Deprecated: Use <code>getPort().getName()</code> instead.
+     *
+     * @return Port name
      */
-    public String getPortName(){
-        return portName;
+    @Deprecated
+    public String getPortName() {
+        return port != null ? port.getPortName() : portName;
     }
 
     /**
-     * Getting method name during execution of which the exception was called
+     * Gets the <code>SerialPort</code> which threw the exception
+     *
+     * @return <code>SerialPort</code> object
      */
-    public String getMethodName(){
+    @SuppressWarnings("unused")
+    public SerialPort getPort() {
+        return port;
+    }
+
+    /**
+     * Gets the method name during execution of which the exception was called
+     *
+     * @return Calling method name
+     */
+    @SuppressWarnings("unused")
+    public String getMethodName() {
         return methodName;
     }
 
     /**
-     * Getting timeout value in millisecond
+     * Gets timeout value of which the exception was called
+     *
+     * @return Calling method name
      */
-    public int getTimeoutValue(){
+    @SuppressWarnings("unused")
+    public int getTimeoutValue() {
         return timeoutValue;
     }
 }


### PR DESCRIPTION
The javadocs are riddled with warnings.  Some are benign and should be suppressed through configuration, others are sane warnings that warrant better commenting.

~~This is a work in progress.  At time of writing this, I'm not sure how to `-Xlint`-out some of these, so this PR may not make it in for the 2.9.3 release.~~

**Edit:** I've decided to not try to `-Xlint` them out and just added some placeholder comments for stuff like `@throws`.  If the binaries test well, we'll merge prior to the new release.

**Edit:** This is ready for review and merge, awaiting approval by @GMKennedy.