### PR TITLE
Add static linking for llvm-mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,16 +55,14 @@ if(APPLE)
 endif()
 
 # Statically link gcc/c++
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	if(WIN32)
-		# Assume mingw, use "-static"
-		set(CMAKE_CXX_STANDARD_LIBRARIES "-static ${CMAKE_CXX_STANDARD_LIBRARIES}")
-	elseif(NOT CMAKE_SYSTEM_NAME STREQUAL SunOS)
-		set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ ${CMAKE_CXX_STANDARD_LIBRARIES}")
-	endif()
-elseif(MSVC)
+if(MSVC)
 	# /MT = Multithread, static version of the run-time library
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+elseif(WIN32)
+	# Assume mingw, use "-static"
+	set(CMAKE_CXX_STANDARD_LIBRARIES "-static ${CMAKE_CXX_STANDARD_LIBRARIES}")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+	set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Apply mingw flags to clang too.
Previous logic assumed mingw was a gcc variant per `CMAKE_CXX_COMPILER_ID STREQUAL "GNU"`.  Adds `-static` flag for llvm-mingw (clang) too.

Closes #108 