### PR TITLE
Update readme with latest released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A small, single Java library for working with serial ports across various system
 <dependency>
     <groupId>io.github.java-native</groupId>
     <artifactId>jssc</artifactId>
-    <version>2.9.2</version>
+    <version>2.9.3</version>
 </dependency>
 ```
 * or Gradle (KTS)
@@ -17,7 +17,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("io.github.java-native:jssc:2.9.2")
+    implementation("io.github.java-native:jssc:2.9.3")
 }
 ```
 * or Gradle (Groovy)
@@ -26,7 +26,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation 'io.github.java-native:jssc:2.9.2'
+    implementation 'io.github.java-native:jssc:2.9.3'
 }
 ```
 * [API code examples](../../wiki/examples)


### PR DESCRIPTION
The release is out in
https://search.maven.org/artifact/io.github.java-native/jssc/2.9.3/jar
