### PR TITLE
GitHub autorelease

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -38,5 +38,73 @@ jobs:
           OSSRH_TOKEN_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}
           OSSRH_TOKEN_PASSWORD: ${{ secrets.OSSRH_TOKEN_PASSWORD }}
           PGP_KEY_PASSPHRASE: ${{ secrets.JAVA_NATIVE_PGP_KEY_PASSPHRASE }}
+      - run: echo "releaseTag=$(git tag --points-at HEAD^)" >> $GITHUB_ENV
+      - run: echo "releaseVersion=$(echo ${{ env.releaseTag }} | cut -c2-)" >> $GITHUB_ENV
       - name: Push changes back to repo
         run: git push && git push --tags --force
+    outputs:
+      releaseTag: ${{ env.releaseTag }}
+      releaseVersion: ${{ env.releaseVersion }}
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs: maven-central-release
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.maven-central-release.outputs.releaseTag }}
+      - run: git config --global user.email "${GITHUB_BOT_EMAIL}"
+      - run: git config --global user.name "${GITHUB_BOT_NAME}"
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: temurin
+      - name: Build jar with dependencies included
+        run: mvn -B install -Ppackage,jar-with-dependencies
+      - name: Publish as release
+        uses: ncipollo/release-action@v1
+        with:
+          name: ${{ needs.maven-central-release.outputs.releaseVersion }}
+          tag: ${{ needs.maven-central-release.outputs.releaseTag }}
+          allowUpdates: true
+          artifacts: target/*.jar
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  update-readme:
+    runs-on: ubuntu-latest
+    needs: maven-central-release
+    env:
+      ver: ${{ needs.maven-central-release.outputs.releaseVersion }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+            git config --global user.email "${GITHUB_BOT_EMAIL}"
+            git config --global user.name "${GITHUB_BOT_NAME}"
+      - run: |
+            sed -i "/<artifactId>jssc<\/artifactId>/{n;s/<version>.*<\/version>/<version>${ver}<\/version>/}" README.md
+            sed -i'.bak' -e "s/java-native:jssc:[A-Za-z0-9.-]*/java-native:jssc:${ver}/g" README.md
+      - run: |
+          if [ $(git ls-files --modified) ]; then
+            git commit --all --message "Update versions in source files after new release" && git pull --rebase && git push
+          fi
+
+  update-wiki:
+    runs-on: ubuntu-latest
+    needs: maven-central-release
+    env:
+      ver: ${{ needs.maven-central-release.outputs.releaseVersion }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}.wiki
+      - run: |
+          git config --global user.email "${GITHUB_BOT_EMAIL}"
+          git config --global user.name "${GITHUB_BOT_NAME}"
+      - run: |
+          sed -i "/<artifactId>jssc<\/artifactId>/{n;s/<version>.*<\/version>/<version>${ver}<\/version>/}" Add-Dependency.md
+          sed -i'.bak' -e "s/java-native:jssc:[A-Za-z0-9.-]*/java-native:jssc:${ver}/g" Add-Dependency.md
+      - run: |
+          if [ $(git ls-files --modified) ]; then
+            git commit --all --message "Update wiki with latest version released to Maven Central" && git pull --rebase && git push
+          fi

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -1,0 +1,42 @@
+name: Release New Version
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version'
+        required: false
+
+env:
+  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  JAVA_TOOL_OPTIONS: -Duser.name=io.github.java-native
+  GITHUB_BOT_NAME: github-actions
+  GITHUB_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+jobs:
+  maven-central-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git config --global user.email "${GITHUB_BOT_EMAIL}"
+      - run: git config --global user.name "${GITHUB_BOT_NAME}"
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: temurin
+          server-id: ossrh
+          server-username: OSSRH_TOKEN_USERNAME
+          server-password: OSSRH_TOKEN_PASSWORD
+          gpg-private-key: ${{ secrets.JAVA_NATIVE_PGP_KEY }}
+          gpg-passphrase: PGP_KEY_PASSPHRASE
+      - name: Set release version if provided as input
+        if: github.event.inputs.releaseVersion != ''
+        run: echo "VERSIONS=-DreleaseVersion=${{ github.event.inputs.releaseVersion }}" >> $GITHUB_ENV
+      - name: Publish artifacts to Maven Central
+        run: mvn -B release:prepare release:perform -P package,maven-central-release ${VERSIONS}
+        env:
+          OSSRH_TOKEN_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}
+          OSSRH_TOKEN_PASSWORD: ${{ secrets.OSSRH_TOKEN_PASSWORD }}
+          PGP_KEY_PASSPHRASE: ${{ secrets.JAVA_NATIVE_PGP_KEY_PASSPHRASE }}
+      - name: Push changes back to repo
+        run: git push && git push --tags --force

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,7 @@
             </goals>
             <configuration>
               <skipAssembly>${jar.dependencies.skip}</skipAssembly>
+              <appendAssemblyId>false</appendAssemblyId>
               <descriptorRefs>
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <connection>scm:git:https://github.com/java-native/jssc.git</connection>
     <developerConnection>scm:git:git@github.com:java-native/jssc.git</developerConnection>
     <url>https://github.com/java-native/jssc</url>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>
@@ -63,10 +64,13 @@
     <plugin.build-helper-maven-version>3.2.0</plugin.build-helper-maven-version>
     <plugin.compiler.version>3.8.0</plugin.compiler.version>
     <plugin.enforcer.version>3.0.0-M3</plugin.enforcer.version>
+    <plugin.gpg.version>3.0.1</plugin.gpg.version>
     <plugin.jar.version>3.1.1</plugin.jar.version>
     <plugin.javadoc.version>3.1.1</plugin.javadoc.version>
     <plugin.nar.version>3.6.0</plugin.nar.version>
+    <plugin.nexus-staging.version>1.6.7</plugin.nexus-staging.version>
     <plugin.osmaven.version>1.7.0</plugin.osmaven.version>
+    <plugin.release.version>3.0.0-M4</plugin.release.version>
     <plugin.signature.version>1.1</plugin.signature.version>
     <plugin.source.version>3.0.1</plugin.source.version>
     <plugin.surfire.version>3.0.0-M4</plugin.surfire.version>
@@ -447,7 +451,7 @@
              <execution>
                <id>attach-sources</id>
                <goals>
-                 <goal>jar</goal>
+                 <goal>jar-no-fork</goal>
                </goals>
              </execution>
            </executions>
@@ -572,6 +576,57 @@
         <os.target.arch>arm_32</os.target.arch>
         <os.target.bitness>32</os.target.bitness>
       </properties>
+    </profile>
+
+    <profile>
+      <id>maven-central-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${plugin.gpg.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <keyname>java-native</keyname>
+              <passphraseServerId>gpg.passphrase</passphraseServerId>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>${plugin.release.version}</version>
+            <configuration>
+              <tagNameFormat>v@{project.version}</tagNameFormat>
+              <pushChanges>false</pushChanges>
+              <localCheckout>true</localCheckout>
+              <goals>deploy</goals>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>${plugin.nexus-staging.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>


### PR DESCRIPTION
An extension to #101 
Automates post-release cleanup activities:
- Creating github release from the correctly built artifact
- Update source files that use project version (readme, SerialNativeInterface)