### PR TITLE
Copy native libraries to source tree with Maven action executed only on explicit demand and after a test phase

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -118,7 +118,7 @@ jobs:
                 ${{ matrix.image }} \
                 bash -c \
                   'apt-get update && apt-get install --yes maven openjdk-11-jdk-headless && \
-                   mvn -B clean install -P dockcross \
+                   mvn -B clean install -P dockcross,update-resources-precompiled \
                     -Dos.target.name=${{ matrix.os_target_name }} \
                     -Dos.target.arch=${{ matrix.os_target_arch }} \
                     -Dos.target.bitness=${{ matrix.os_target_bitness }} \
@@ -171,7 +171,7 @@ jobs:
           export SDKROOT=$XCODE_12_DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/${{ matrix.sdk-version }}
           export CMAKE_OSX_SYSROOT=$SDKROOT
       - name: Build with Maven
-        run: mvn -B clean install -P ${{ matrix.profile }}
+        run: mvn -B clean install -P ${{ matrix.profile }},update-resources-precompiled
 
       - name: Push recompiled binaries
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,11 +191,8 @@ if(CMAKE_STRIP AND NOT CMAKE_BUILD_TYPE MATCHES "Deb")
 	add_custom_command(TARGET jssc POST_BUILD COMMAND "${CMAKE_STRIP}" ${STRIP_ARGS} $<TARGET_FILE:jssc>)
 endif()
 
-
+# Copy native library to target/classes for processing by maven
 add_custom_command(TARGET jssc POST_BUILD
-    # Copy native library back to source tree
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/natives/ ${CMAKE_CURRENT_SOURCE_DIR}/src/main/resources-precompiled/natives/
-    # Copy native library back to target/classes tree
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/natives/ ${CMAKE_CURRENT_BINARY_DIR}/../classes/natives/
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ if(CMAKE_STRIP AND NOT CMAKE_BUILD_TYPE MATCHES "Deb")
 	add_custom_command(TARGET jssc POST_BUILD COMMAND "${CMAKE_STRIP}" ${STRIP_ARGS} $<TARGET_FILE:jssc>)
 endif()
 
-# Copy native library to target/classes for processing by maven
+# Copy native library to target/classes for processing by junit, maven
 add_custom_command(TARGET jssc POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/natives/ ${CMAKE_CURRENT_BINARY_DIR}/../classes/natives/
 )

--- a/ant/build.xml
+++ b/ant/build.xml
@@ -289,4 +289,10 @@
             <arg line="${cmake.build.arg}"/>
         </exec>
     </target>
+
+    <target name="update-resources-precompiled">
+        <copy todir="${ant.project.basedir}/src/main/resources-precompiled/natives/">
+            <fileset dir="${cmake.generated.directory}/natives/" includes="**" />
+        </copy>
+    </target>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <plugin.signature.version>1.1</plugin.signature.version>
     <plugin.source.version>3.0.1</plugin.source.version>
     <plugin.surfire.version>3.0.0-M4</plugin.surfire.version>
+    <update-resources-precompiled.skip>true</update-resources-precompiled.skip>
   </properties>
 
   <dependencies>
@@ -243,6 +244,18 @@
               <skip>${cmake.build.skip}</skip>
               <target>
                 <ant dir="ant" target="cmake-build" />
+              </target>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>update-resources-precompiled</id>
+            <phase>prepare-package</phase>
+            <goals><goal>run</goal></goals>
+            <configuration>
+              <skip>${update-resources-precompiled.skip}</skip>
+              <target>
+                <ant dir="ant" target="update-resources-precompiled" />
               </target>
             </configuration>
           </execution>
@@ -429,6 +442,14 @@
       </activation>
       <properties>
         <target.java.version>7</target.java.version>
+      </properties>
+    </profile>
+
+    <!-- Copy newly built native libraries back to source tree -->
+    <profile>
+      <id>update-resources-precompiled</id>
+      <properties>
+        <update-resources-precompiled.skip>false</update-resources-precompiled.skip>
       </properties>
     </profile>
 


### PR DESCRIPTION
Following on the discussion https://github.com/java-native/jssc/pull/151#issuecomment-1804918571 I suggest making maven the party responsible for copying newly compiled binaries to source tree from where they can be commited to git. It can be done so `src/main/resources-precompiled/natives` are updated only after maven is done testing. Additionally, I put the step in separate profile, so without expliclty specifying it, no src modification will take place.