### PR TITLE
Shows the name of the current test in the maven logs

### DIFF
--- a/src/test/java/jssc/SerialNativeInterfaceTest.java
+++ b/src/test/java/jssc/SerialNativeInterfaceTest.java
@@ -1,5 +1,6 @@
 package jssc;
 
+import jssc.junit.rules.DisplayMethodNameRule;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +14,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
-public class SerialNativeInterfaceTest {
+public class SerialNativeInterfaceTest extends DisplayMethodNameRule {
 
     @Test
     public void testInitNativeInterface() {

--- a/src/test/java/jssc/VirtualPortTest.java
+++ b/src/test/java/jssc/VirtualPortTest.java
@@ -24,12 +24,14 @@ import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+
+import jssc.junit.rules.DisplayMethodNameRule;
 import jssc.junit.rules.VirtualPortRule;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class VirtualPortTest {
+public class VirtualPortTest extends DisplayMethodNameRule {
 
   private static final String HELLO_WORLD = "Hello, world!";
 

--- a/src/test/java/jssc/bootpath/ManualBootLibraryPathFailedTest.java
+++ b/src/test/java/jssc/bootpath/ManualBootLibraryPathFailedTest.java
@@ -1,6 +1,7 @@
 package jssc.bootpath;
 
 import jssc.SerialNativeInterface;
+import jssc.junit.rules.DisplayMethodNameRule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -16,7 +17,7 @@ import static org.junit.Assert.fail;
  * - maven-surefire-plugin DOES offer JVM unloading between classes using <code>reuseForks=false</code>
  * - Unloading is needed due to NativeLoader.loadLibrary(...) calls System.loadLibrary(...) which is static
  */
-public class ManualBootLibraryPathFailedTest {
+public class ManualBootLibraryPathFailedTest extends DisplayMethodNameRule {
     @Test
     public void testBootPathOverride() {
         String nativeLibDir = "/"; // This should be valid on all platforms

--- a/src/test/java/jssc/bootpath/ManualBootLibraryPathTest.java
+++ b/src/test/java/jssc/bootpath/ManualBootLibraryPathTest.java
@@ -1,6 +1,7 @@
 package jssc.bootpath;
 
 import jssc.SerialNativeInterface;
+import jssc.junit.rules.DisplayMethodNameRule;
 import org.junit.Test;
 import org.scijava.nativelib.NativeLibraryUtil;
 
@@ -18,7 +19,7 @@ import static org.junit.Assert.fail;
  * - maven-surefire-plugin DOES offer JVM unloading between classes using <code>reuseForks=false</code>
  * - Unloading is needed due to NativeLoader.loadLibrary(...) calls System.loadLibrary(...) which is static
  */
-public class ManualBootLibraryPathTest {
+public class ManualBootLibraryPathTest extends DisplayMethodNameRule {
     @Test
     public void testBootPathOverride() {
         String nativeLibDir = NativeLibraryUtil.getPlatformLibraryPath(System.getProperty("user.dir") + "/target/cmake/natives/");

--- a/src/test/java/jssc/common/ConsoleColor.java
+++ b/src/test/java/jssc/common/ConsoleColor.java
@@ -1,0 +1,23 @@
+package jssc.common;
+
+public enum ConsoleColor {
+    ANSI_RESET(0),
+    ANSI_BLACK(30),
+    ANSI_RED(31),
+    ANSI_GREEN(32),
+    ANSI_YELLOW(33),
+    ANSI_BLUE(34),
+    ANSI_PURPLE(35),
+    ANSI_CYAN(36),
+    ANSI_WHITE(37);
+
+    String colorCode;
+    ConsoleColor(int colorCode) {
+        this.colorCode = "\u001B[" + colorCode + "m";
+    }
+
+    @Override
+    public String toString() {
+        return colorCode;
+    }
+}

--- a/src/test/java/jssc/common/ConsoleStyle.java
+++ b/src/test/java/jssc/common/ConsoleStyle.java
@@ -1,0 +1,51 @@
+package jssc.common;
+
+import org.junit.runner.Description;
+
+import static jssc.common.ConsoleColor.*;
+
+/**
+ * Utility class for coloring a console message similar to JUnit 4
+ */
+public enum ConsoleStyle {
+    INFO,
+    WARNING,
+    ERROR;
+
+    public String colorize(String message) {
+        // e.g. [INFO] --- surefire:3.0.0-M4:test (default-test) @ jssc ---
+        return String.format("%s --- %s @ %s",
+                getPrefix(),
+                styleMessage(ANSI_GREEN, "surefire:" + message),
+                styleMessage(ANSI_CYAN, "jssc"));
+    }
+
+    public String colorize(Description description) {
+        return colorize(description.getMethodName());
+    }
+
+    private ConsoleColor getColor() {
+        switch(this) {
+            case ERROR:
+                return ANSI_RED;
+            case WARNING:
+                return ANSI_YELLOW;
+            case INFO:
+            default:
+                return ANSI_BLUE;
+        }
+    }
+
+    private String styleSeverity() {
+        return styleMessage(getColor(), name());
+    }
+
+    private static String styleMessage(ConsoleColor color, String message) {
+        return color + message + ANSI_RESET;
+    }
+
+    private String getPrefix() {
+        return ANSI_RESET + "[" + styleSeverity() + "]";
+    }
+
+}

--- a/src/test/java/jssc/common/ConsoleStyle.java
+++ b/src/test/java/jssc/common/ConsoleStyle.java
@@ -5,7 +5,7 @@ import org.junit.runner.Description;
 import static jssc.common.ConsoleColor.*;
 
 /**
- * Utility class for coloring a console message similar to JUnit 4
+ * Utility class for coloring a console message similar to maven
  */
 public enum ConsoleStyle {
     INFO,

--- a/src/test/java/jssc/junit/rules/DisplayMethodNameRule.java
+++ b/src/test/java/jssc/junit/rules/DisplayMethodNameRule.java
@@ -1,0 +1,26 @@
+package jssc.junit.rules;
+
+import org.junit.Rule;
+import org.junit.rules.*;
+import org.junit.runner.*;
+
+import static jssc.common.ConsoleStyle.*;
+
+/**
+ * Adds the method name to the JUnit logs, useful for debugging
+ */
+public class DisplayMethodNameRule {
+    @Rule
+    public TestWatcher testWatcher = new TestWatcher() {
+        @Override
+        protected void starting(Description description) {
+            /*String nl = System.getProperty("line.separator");
+            System.out.println(String.format(nl +
+                            "-------------------------------------------------------" + nl +
+                            "METHOD: %s" + nl +
+                            "-------------------------------------------------------",
+                    description.getMethodName()));*/
+            System.out.println(INFO.colorize(description));
+        }
+    };
+}

--- a/src/test/java/jssc/junit/rules/DisplayMethodNameRule.java
+++ b/src/test/java/jssc/junit/rules/DisplayMethodNameRule.java
@@ -14,12 +14,6 @@ public class DisplayMethodNameRule {
     public TestWatcher testWatcher = new TestWatcher() {
         @Override
         protected void starting(Description description) {
-            /*String nl = System.getProperty("line.separator");
-            System.out.println(String.format(nl +
-                            "-------------------------------------------------------" + nl +
-                            "METHOD: %s" + nl +
-                            "-------------------------------------------------------",
-                    description.getMethodName()));*/
             System.out.println(INFO.colorize(description));
         }
     };


### PR DESCRIPTION
Purpose:
* Adds a few utility classes to customize the styling from within JUnit to match that of maven
* Adds the method name of the current test being run in green

Closes #156 

Output from the GitHub runner:
```bash
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running jssc.bootpath.ManualBootLibraryPathFailedTest
[INFO] --- surefire:testBootPathOverride @ jssc
#                   ^----------------------------------- HERE
```

Output from a console that supports color:
![junit_method_names2](https://github.com/java-native/jssc/assets/6345473/c563e5bf-9077-4ea8-aaf7-cc384cf1d021)
