### PR TITLE
Make JSSC exceptions extend IOException instead of Exception

### DIFF
--- a/src/main/java/jssc/SerialPortException.java
+++ b/src/main/java/jssc/SerialPortException.java
@@ -24,11 +24,13 @@
  */
 package jssc;
 
+import java.io.IOException;
+
 /**
  *
  * @author scream3r
  */
-public class SerialPortException extends Exception {
+public class SerialPortException extends IOException {
     final private static long serialVersionUID = 1L;
     /** Port already opened **/
     final public static String TYPE_PORT_ALREADY_OPENED = "Port already opened";

--- a/src/main/java/jssc/SerialPortTimeoutException.java
+++ b/src/main/java/jssc/SerialPortTimeoutException.java
@@ -24,11 +24,13 @@
  */
 package jssc;
 
+import java.io.IOException;
+
 /**
  *
  * @author scream3r
  */
-public class SerialPortTimeoutException extends Exception {
+public class SerialPortTimeoutException extends IOException {
     final private static long serialVersionUID = 1L;
 
     /** Serial port object **/


### PR DESCRIPTION
Make JSSC exceptions extend `IOException` instead of `Exception`.

# The change

This is a change in the class hierarchy for both custom exceptions in JSSC. Both currently extend `Exception`, and this changes them to extend `IOException` instead, which is a subclass of `Exception`. This naturally makes sense as any serial port interactions are IO interactions. This should be a transparent change to all existing code, as any code catching the exceptions by exact name would be unaffected, and any code catching `Exception` will also catch `IOException` without change.

# The why

If I'm writing a library that interacts with the serial interface, almost every method throws exceptions, and most of the time I want to pass them on to my caller to decide how to handle them. So if my code has a public method that interacts with the serial interface, I can:
1. Add throws `jssc.SerialPortException` to my method signature (and potentially also `jssc.SerialPortTimeoutException`, since they don't have a common parent other than `Exception`)
2. Add throws `Exception` to my method signature
3. Catch `jssc.SerialPortException` myself and wrap in a more neutral exception, like `IOException`.

Option one is gross because it leaks JSSC classes in my public API signatures to my clients. As a direct user of JSSC, I don't care much about what exceptions JSSC defines. But as a library author that uses JSSC, I don't want JSSC classes to leak into my public API, as the underlying serial library is an implementation detail. This would limit me if I wanted to support adapters for other serial libraries.

Option two is gross because anything that causes one to need to catch `Exception` is very bad form, because then there's the risk of catching exceptions you didn't want to catch like `OutOfMemoryError`.

That leaves me with option three. In every JSSC serial project I make, there ends up being an adapter to wrap the serial port and sanitize the exceptions, a la:

```java
    /** {@inheritDoc} */
    @Override
    public boolean write(byte b) throws IOException {
        try {
            return serialPort.writeByte(b);
        } catch (SerialPortException e) {
            throw new IOException(e);
        }
    }

    /** {@inheritDoc} */
    @Override
    public boolean write(byte[] bytes) throws IOException {
        try {
            return serialPort.writeBytes(bytes);
        } catch (SerialPortException e) {
            throw new IOException(e);
        }
    }

    /** {@inheritDoc} */
    @Override
    public byte[] readBytes(int byteCount) throws IOException {
        try {
            return serialPort.readBytes(byteCount);
        } catch (SerialPortException e) {
            throw new IOException(e);
        }
    }

    /** {@inheritDoc} */
    @Override
    public void close() throws IOException {
        if (serialPort.isOpened()) {
            try {
                serialPort.closePort();
            } catch (SerialPortException e) {
                throw new IOException("Error closing serial port", e);
            }
        }
    }
```

Hence this change, which by moving the exceptions to extend `IOException` make all of this wrapping unnecessary, as the client can catch `IOException` without knowing the JSSC specific exceptions exist.