### PR TITLE
Ensure socat process is correctly terminated after test execution

### DIFF
--- a/src/test/java/jssc/junit/rules/VirtualPortRule.java
+++ b/src/test/java/jssc/junit/rules/VirtualPortRule.java
@@ -99,7 +99,7 @@ public class VirtualPortRule implements TestRule {
         } finally {
           // stop socat
           for (final Future<?> process : VirtualPortRule.this.processes) {
-            process.cancel(false);
+            process.cancel(true);
           }
 
           executor.shutdown();


### PR DESCRIPTION
It looks like the socat process launched by the unit tests is never actually closed. 