### PR TITLE
Update Junit version to address CVE-2020-15250

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <jar.dependencies.skip>true</jar.dependencies.skip>
 
     <!-- dependency versions a-z -->
-    <dependency.junit.version>4.12</dependency.junit.version>
+    <dependency.junit.version>4.13.2</dependency.junit.version>
     <dependency.log4j.version>2.22.0</dependency.log4j.version>
     <dependency.logback.version>1.2.3</dependency.logback.version>
     <dependency.nativelibloader.version>2.5.0</dependency.nativelibloader.version>


### PR DESCRIPTION
Junit 4.12 is flagged as vulnerable to [CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250). Although realistically this is not a threat to library users, it's worth updating to avoid being flagged on [Maven Central](https://mvnrepository.com/artifact/io.github.java-native/jssc/2.9.5).