### PR TITLE
Add org.jetbrains.annotations support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,13 @@
       <version>${dependency.junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations-java5</artifactId>
+      <version>24.1.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/jssc/SerialNativeInterface.java
+++ b/src/main/java/jssc/SerialNativeInterface.java
@@ -24,6 +24,7 @@
  */
 package jssc;
 
+import org.intellij.lang.annotations.MagicConstant;
 import org.scijava.nativelib.NativeLoader;
 
 import java.io.IOException;
@@ -141,6 +142,13 @@ public class SerialNativeInterface {
      * 
      * @since 0.8
      */
+    @MagicConstant(intValues = {
+            OS_LINUX,
+            OS_WINDOWS,
+            OS_SOLARIS,
+            OS_MAC_OS_X,
+            OS_UNKNOWN,
+    })
     public static int getOsType() {
         return osType;
     }

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -24,6 +24,8 @@
  */
 package jssc;
 
+import org.intellij.lang.annotations.MagicConstant;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
@@ -241,7 +243,46 @@ public class SerialPort {
      *
      * @throws SerialPortException if exception occurred
      */
-    public boolean setParams(int baudRate, int dataBits, int stopBits, int parity) throws SerialPortException {
+    public boolean setParams(
+            @MagicConstant(intValues = {
+                    BAUDRATE_110,
+                    BAUDRATE_300,
+                    BAUDRATE_600,
+                    BAUDRATE_1200,
+                    BAUDRATE_2400,
+                    BAUDRATE_4800,
+                    BAUDRATE_9600,
+                    BAUDRATE_14400,
+                    BAUDRATE_19200,
+                    BAUDRATE_38400,
+                    BAUDRATE_57600,
+                    BAUDRATE_115200,
+                    BAUDRATE_128000,
+                    BAUDRATE_256000,
+            })
+            int baudRate,
+            @MagicConstant(intValues = {
+                    DATABITS_5,
+                    DATABITS_6,
+                    DATABITS_7,
+                    DATABITS_8,
+            })
+            int dataBits,
+            @MagicConstant(intValues = {
+                    STOPBITS_1,
+                    STOPBITS_2,
+                    STOPBITS_1_5,
+            })
+            int stopBits,
+            @MagicConstant(intValues = {
+                    PARITY_NONE,
+                    PARITY_ODD,
+                    PARITY_EVEN,
+                    PARITY_MARK,
+                    PARITY_SPACE,
+            })
+            int parity
+    ) throws SerialPortException {
         return setParams(baudRate, dataBits, stopBits, parity, true, true);
     }
 
@@ -261,7 +302,48 @@ public class SerialPort {
      *
      * @since 0.8
      */
-    public synchronized boolean setParams(int baudRate, int dataBits, int stopBits, int parity, boolean setRTS, boolean setDTR) throws SerialPortException {
+    public synchronized boolean setParams(
+            @MagicConstant(intValues = {
+                    BAUDRATE_110,
+                    BAUDRATE_300,
+                    BAUDRATE_600,
+                    BAUDRATE_1200,
+                    BAUDRATE_2400,
+                    BAUDRATE_4800,
+                    BAUDRATE_9600,
+                    BAUDRATE_14400,
+                    BAUDRATE_19200,
+                    BAUDRATE_38400,
+                    BAUDRATE_57600,
+                    BAUDRATE_115200,
+                    BAUDRATE_128000,
+                    BAUDRATE_256000,
+            })
+            int baudRate,
+            @MagicConstant(intValues = {
+                    DATABITS_5,
+                    DATABITS_6,
+                    DATABITS_7,
+                    DATABITS_8,
+            })
+            int dataBits,
+            @MagicConstant(intValues = {
+                    STOPBITS_1,
+                    STOPBITS_2,
+                    STOPBITS_1_5,
+            })
+            int stopBits,
+            @MagicConstant(intValues = {
+                    PARITY_NONE,
+                    PARITY_ODD,
+                    PARITY_EVEN,
+                    PARITY_MARK,
+                    PARITY_SPACE,
+            })
+            int parity,
+            boolean setRTS,
+            boolean setDTR
+    ) throws SerialPortException {
         checkPortOpened("setParams()");
         if(stopBits == 1){
             stopBits = 0;
@@ -292,7 +374,15 @@ public class SerialPort {
      *
      * @throws SerialPortException if exception occurred
      */
-    public synchronized boolean purgePort(int flags) throws SerialPortException {
+    public synchronized boolean purgePort(
+            @MagicConstant(intValues = {
+                    PURGE_RXABORT,
+                    PURGE_RXCLEAR,
+                    PURGE_TXABORT,
+                    PURGE_TXCLEAR,
+            })
+            int flags
+    ) throws SerialPortException {
         checkPortOpened("purgePort()");
         return serialInterface.purgePort(portHandle, flags);
     }
@@ -317,7 +407,20 @@ public class SerialPort {
      *
      * @throws SerialPortException if exception occurred
      */
-    public synchronized boolean setEventsMask(int mask) throws SerialPortException {
+    public synchronized boolean setEventsMask(
+            @MagicConstant(intValues = {
+                    MASK_RXCHAR,
+                    MASK_RXFLAG,
+                    MASK_TXEMPTY,
+                    MASK_CTS,
+                    MASK_DSR,
+                    MASK_RLSD,
+                    MASK_BREAK,
+                    MASK_ERR,
+                    MASK_RING,
+            })
+            int mask
+    ) throws SerialPortException {
         checkPortOpened("setEventsMask()");
         if(SerialNativeInterface.getOsType() == SerialNativeInterface.OS_LINUX ||
            SerialNativeInterface.getOsType() == SerialNativeInterface.OS_SOLARIS ||
@@ -917,7 +1020,16 @@ public class SerialPort {
      *
      * @since 0.8
      */
-    public boolean setFlowControlMode(int mask) throws SerialPortException {
+    public boolean setFlowControlMode(
+            @MagicConstant(intValues = {
+                    FLOWCONTROL_NONE,
+                    FLOWCONTROL_RTSCTS_IN,
+                    FLOWCONTROL_RTSCTS_OUT,
+                    FLOWCONTROL_XONXOFF_IN,
+                    FLOWCONTROL_XONXOFF_OUT,
+            })
+            int mask
+    ) throws SerialPortException {
         checkPortOpened("setFlowControlMode()");
         return serialInterface.setFlowControlMode(portHandle, mask);
     }
@@ -931,6 +1043,13 @@ public class SerialPort {
      *
      * @since 0.8
      */
+    @MagicConstant(intValues = {
+            FLOWCONTROL_NONE,
+            FLOWCONTROL_RTSCTS_IN,
+            FLOWCONTROL_RTSCTS_OUT,
+            FLOWCONTROL_XONXOFF_IN,
+            FLOWCONTROL_XONXOFF_OUT,
+    })
     public int getFlowControlMode() throws SerialPortException {
         checkPortOpened("getFlowControlMode()");
         return serialInterface.getFlowControlMode(portHandle);
@@ -1299,6 +1418,11 @@ public class SerialPort {
                 int[][] eventArray = waitEvents();
                 int mask = getLinuxMask();
                 boolean interruptTxChanged = false;
+                @MagicConstant(flags = {
+                        ERROR_FRAME,
+                        ERROR_OVERRUN,
+                        ERROR_PARITY,
+                })
                 int errorMask = 0;
                 for(int[] event : eventArray){
                     boolean sendEvent = false;

--- a/src/main/java/jssc/SerialPortEvent.java
+++ b/src/main/java/jssc/SerialPortEvent.java
@@ -24,6 +24,10 @@
  */
 package jssc;
 
+import org.intellij.lang.annotations.MagicConstant;
+
+import static jssc.SerialPort.*;
+
 /**
  *
  * @author scream3r
@@ -40,15 +44,15 @@ public class SerialPortEvent {
 
     /** Deprecated: Use <code>SerialPort.MASK_RXCHAR</code> instead **/
     @Deprecated
-    public static final int RXCHAR = SerialPort.MASK_RXCHAR;
+    public static final int RXCHAR = MASK_RXCHAR;
 
     /** Deprecated: Use <code>SerialPort.MASK_RXFLAG</code> instead **/
     @Deprecated
-    public static final int RXFLAG = SerialPort.MASK_RXFLAG;
+    public static final int RXFLAG = MASK_RXFLAG;
 
     /** Deprecated: Use <code>SerialPort.MASK_TXEMPTY</code> instead **/
     @Deprecated
-    public static final int TXEMPTY = SerialPort.MASK_TXEMPTY;
+    public static final int TXEMPTY = MASK_TXEMPTY;
 
     /** Deprecated: Use <code>SerialPort.MASK_CTS</code> instead **/
     @Deprecated
@@ -83,7 +87,22 @@ public class SerialPortEvent {
      *
      * @see #getEventType()
      */
-    public SerialPortEvent(SerialPort port, int eventType, int eventValue){
+    public SerialPortEvent(
+            SerialPort port,
+            @MagicConstant(intValues = {
+                    MASK_RXCHAR,
+                    MASK_RXFLAG,
+                    MASK_TXEMPTY,
+                    MASK_CTS,
+                    MASK_DSR,
+                    MASK_RLSD,
+                    MASK_BREAK,
+                    MASK_ERR,
+                    MASK_RING,
+            })
+            int eventType,
+            int eventValue
+    ){
         this.port = port;
         this.eventType = eventType;
         this.eventValue = eventValue;
@@ -100,7 +119,22 @@ public class SerialPortEvent {
      * @see #SerialPortEvent(SerialPort, int, int)
      */
     @Deprecated
-    public SerialPortEvent(String portName, int eventType, int eventValue){
+    public SerialPortEvent(
+            String portName,
+            @MagicConstant(intValues = {
+                    MASK_RXCHAR,
+                    MASK_RXFLAG,
+                    MASK_TXEMPTY,
+                    MASK_CTS,
+                    MASK_DSR,
+                    MASK_RLSD,
+                    MASK_BREAK,
+                    MASK_ERR,
+                    MASK_RING,
+            })
+            int eventType,
+            int eventValue
+    ){
         this.portName = portName;
         this.eventType = eventType;
         this.eventValue = eventValue;
@@ -131,6 +165,17 @@ public class SerialPortEvent {
      * @return The <code>SerialPort.MASK_*</code> event mask
      */
     @SuppressWarnings("unused")
+    @MagicConstant(intValues = {
+            MASK_RXCHAR,
+            MASK_RXFLAG,
+            MASK_TXEMPTY,
+            MASK_CTS,
+            MASK_DSR,
+            MASK_RLSD,
+            MASK_BREAK,
+            MASK_ERR,
+            MASK_RING,
+    })
     public int getEventType() {
         return eventType;
     }
@@ -161,7 +206,7 @@ public class SerialPortEvent {
      */
     @SuppressWarnings("unused")
     public boolean isRXCHAR() {
-        return eventType == SerialPort.MASK_RXCHAR;
+        return eventType == MASK_RXCHAR;
     }
 
     /**
@@ -170,7 +215,7 @@ public class SerialPortEvent {
      */
     @SuppressWarnings("unused")
     public boolean isRXFLAG() {
-        return eventType == SerialPort.MASK_RXFLAG;
+        return eventType == MASK_RXFLAG;
     }
 
     /**
@@ -179,7 +224,7 @@ public class SerialPortEvent {
      */
     @SuppressWarnings("unused")
     public boolean isTXEMPTY() {
-        return eventType == SerialPort.MASK_TXEMPTY;
+        return eventType == MASK_TXEMPTY;
     }
 
     /**


### PR DESCRIPTION
I'm trying to add [`org.jetbrains.annotations`](https://github.com/JetBrains/java-annotations) support to core API of this lib. This will give better code completion in IntelliJ IDEA environment and should have no side effects.

Since I do not fully understand the code of this lib, the changes may contain errors and you may need to make a code review.