### PR TITLE
Handle some IllegalArgument cases in readBytes

### DIFF
--- a/src/main/cpp/_nix_based/jssc.cpp
+++ b/src/main/cpp/_nix_based/jssc.cpp
@@ -26,6 +26,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <new> // std::bad_alloc
 #include <string.h>
 #include <unistd.h>
 #include <string.h>

--- a/src/main/cpp/_nix_based/jssc.cpp
+++ b/src/main/cpp/_nix_based/jssc.cpp
@@ -662,16 +662,16 @@ JNIEXPORT jbyteArray JNICALL Java_jssc_SerialNativeInterface_readBytes
     jbyteArray returnArray = NULL;
     int byteRemains = byteCount;
 
-    if( byteCount < 0 ){
+    if( byteCount <= 0 ){
         char emsg[64]; emsg[0] = '\0';
         snprintf(emsg, sizeof emsg, "byteCount %d. Expected range: 1..2147483647", byteCount);
         jclass exClz = env->FindClass("java/lang/IllegalArgumentException");
-        if( exClz != NULL ) env->ThrowNew(exClz, emsg);
+        if( exClz ) env->ThrowNew(exClz, emsg);
         returnArray = NULL; goto Finally;
     }
 
     lpBuffer = (jbyte*)malloc(byteCount*sizeof*lpBuffer);
-    if( !lpBuffer && byteCount ){
+    if( !lpBuffer ){
         char emsg[32]; emsg[0] = '\0';
         snprintf(emsg, sizeof emsg, "malloc(%d) failed", byteCount*sizeof*lpBuffer);
         jclass exClz = env->FindClass("java/lang/RuntimeException");
@@ -725,7 +725,7 @@ JNIEXPORT jbyteArray JNICALL Java_jssc_SerialNativeInterface_readBytes
     assert(env->ExceptionCheck() == JNI_FALSE);
 
 Finally:
-    if( lpBuffer != NULL ) free(lpBuffer);
+    if( lpBuffer ) free(lpBuffer);
     return returnArray;
 }
 

--- a/src/main/cpp/_nix_based/jssc.cpp
+++ b/src/main/cpp/_nix_based/jssc.cpp
@@ -26,7 +26,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <fcntl.h>
-#include <new> // std::bad_alloc
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <string.h>
@@ -670,11 +670,7 @@ JNIEXPORT jbyteArray JNICALL Java_jssc_SerialNativeInterface_readBytes
         returnArray = NULL; goto Finally;
     }
 
-    try{
-        lpBuffer = new jbyte[byteCount];
-    }catch( const std::bad_alloc& ex ){
-        lpBuffer = NULL;
-    }
+    lpBuffer = (jbyte*)malloc(byteCount*sizeof*lpBuffer);
     if( lpBuffer == NULL ){
         char emsg[32]; emsg[0] = '\0';
         snprintf(emsg, sizeof emsg, "new byte[%d]", byteCount);
@@ -729,7 +725,7 @@ JNIEXPORT jbyteArray JNICALL Java_jssc_SerialNativeInterface_readBytes
     assert(env->ExceptionCheck() == JNI_FALSE);
 
 Finally:
-    if( lpBuffer != NULL ) delete[] lpBuffer;
+    if( lpBuffer != NULL ) free(lpBuffer);
     return returnArray;
 }
 

--- a/src/main/cpp/_nix_based/jssc.cpp
+++ b/src/main/cpp/_nix_based/jssc.cpp
@@ -663,19 +663,19 @@ JNIEXPORT jbyteArray JNICALL Java_jssc_SerialNativeInterface_readBytes
     int byteRemains = byteCount;
 
     if( byteCount < 0 ){
-        char emsg[32]; emsg[0] = '\0';
-        snprintf(emsg, sizeof emsg, "new byte[%d]", byteCount);
+        char emsg[64]; emsg[0] = '\0';
+        snprintf(emsg, sizeof emsg, "byteCount %d. Expected range: 1..2147483647", byteCount);
         jclass exClz = env->FindClass("java/lang/IllegalArgumentException");
         if( exClz != NULL ) env->ThrowNew(exClz, emsg);
         returnArray = NULL; goto Finally;
     }
 
     lpBuffer = (jbyte*)malloc(byteCount*sizeof*lpBuffer);
-    if( lpBuffer == NULL ){
+    if( !lpBuffer && byteCount ){
         char emsg[32]; emsg[0] = '\0';
-        snprintf(emsg, sizeof emsg, "new byte[%d]", byteCount);
-        jclass exClz = env->FindClass("java/lang/OutOfMemoryError");
-        if( exClz != NULL ) env->ThrowNew(exClz, emsg);
+        snprintf(emsg, sizeof emsg, "malloc(%d) failed", byteCount*sizeof*lpBuffer);
+        jclass exClz = env->FindClass("java/lang/RuntimeException");
+        if( exClz ) env->ThrowNew(exClz, emsg);
         returnArray = NULL; goto Finally;
     }
 

--- a/src/main/cpp/windows/jssc.cpp
+++ b/src/main/cpp/windows/jssc.cpp
@@ -280,20 +280,19 @@ JNIEXPORT jbyteArray JNICALL Java_jssc_SerialNativeInterface_readBytes
     jbyte *lpBuffer = NULL;
     OVERLAPPED *overlapped = NULL;
 
-    if( byteCount < 0 ){
-        /* Negative byteCount makes no sense -> Report to caller by exception. */
-        char exMsg[48]; exMsg[0] = '\0';
-        snprintf(exMsg, sizeof exMsg, "byteCount %d", byteCount);
+    if( byteCount <= 0 ){
+        char emsg[64]; emsg[0] = '\0';
+        snprintf(emsg, sizeof emsg, "byteCount %d. Expected range: 1..2147483647", byteCount);
         jclass exClz = env->FindClass("java/lang/IllegalArgumentException");
-        if( exClz != NULL ) env->ThrowNew(exClz, exMsg);
-        goto Finally;
+        if( exClz ) env->ThrowNew(exClz, emsg);
+        returnArray = NULL; goto Finally;
     }
 
     returnArray = env->NewByteArray(byteCount);
     if( returnArray == NULL ) goto Finally;
 
     lpBuffer = (jbyte*)malloc(byteCount*sizeof*lpBuffer);
-    if( !lpBuffer && byteCount ){
+    if( !lpBuffer ){
         char emsg[32]; emsg[0] = '\0';
         snprintf(emsg, sizeof emsg, "malloc(%d) failed", byteCount*sizeof*lpBuffer);
         jclass exClz = env->FindClass("java/lang/RuntimeException");
@@ -318,11 +317,11 @@ JNIEXPORT jbyteArray JNICALL Java_jssc_SerialNativeInterface_readBytes
         if( exClz != NULL ) env->ThrowNew(exClz, "EBADF");
     }
 Finally:
-    if( overlapped != NULL ){
+    if( overlapped ){
         CloseHandle(overlapped->hEvent);
         delete overlapped;
     }
-    if( lpBuffer != NULL ) free(lpBuffer);
+    if( lpBuffer ) free(lpBuffer);
     return returnArray;
 }
 

--- a/src/main/cpp/windows/jssc.cpp
+++ b/src/main/cpp/windows/jssc.cpp
@@ -292,14 +292,13 @@ JNIEXPORT jbyteArray JNICALL Java_jssc_SerialNativeInterface_readBytes
     returnArray = env->NewByteArray(byteCount);
     if( returnArray == NULL ) goto Finally;
 
-    lpBuffer = (jbyte *)malloc(byteCount * sizeof(jbyte));
-    if(lpBuffer == NULL){
-        /* Whops. Not enough memory. Let caller know through exception. */
-        char exMsg[32]; exMsg[0] = '\0';
-        snprintf(exMsg, sizeof exMsg, "malloc(%d)", byteCount);
-        jclass exClz = env->FindClass("java/lang/OutOfMemoryError");
-        if( exClz != NULL ) env->ThrowNew(exClz, exMsg);
-        goto Finally;
+    lpBuffer = (jbyte*)malloc(byteCount*sizeof*lpBuffer);
+    if( !lpBuffer && byteCount ){
+        char emsg[32]; emsg[0] = '\0';
+        snprintf(emsg, sizeof emsg, "malloc(%d) failed", byteCount*sizeof*lpBuffer);
+        jclass exClz = env->FindClass("java/lang/RuntimeException");
+        if( exClz ) env->ThrowNew(exClz, emsg);
+        returnArray = NULL; goto Finally;
     }
 
     overlapped = new OVERLAPPED();

--- a/src/test/java/jssc/SerialNativeInterfaceTest.java
+++ b/src/test/java/jssc/SerialNativeInterfaceTest.java
@@ -94,4 +94,34 @@ public class SerialNativeInterfaceTest extends DisplayMethodNameRule {
         new SerialNativeInterface().writeBytes(1, null);
     }
 
+    @Test
+    public void throwsIaeIfCountNegative() throws Exception {
+        SerialNativeInterface testTarget = new SerialNativeInterface();
+        byte[] ret;
+        try{
+            ret = testTarget.readBytes(0, -42);
+            fail("Where's the exception?");
+        }catch( IllegalArgumentException ex ){
+            assertTrue(ex.getMessage().contains("-42"));
+        }
+    }
+
+    @Test
+    @org.junit.Ignore("This test only makes sense if it is run in a situation"
+        +" where large memory allocations WILL fail (for example you could use"
+        +" a virtual machine with low memory available). Because on regular"
+        +" machines allocating 2GiB of RAM is not a problem at all and so the"
+        +" test run will just happily wait infinitely for those 2GiB to arrive"
+        +" at the stdin fd. Feel free to remove this test if you think it"
+        +" doesn't make sense to have it here.")
+    public void throwsOOMExIfRequestTooLarge() throws Exception {
+        SerialNativeInterface testTarget = new SerialNativeInterface();
+        try{
+            byte[] ret = testTarget.readBytes(0, Integer.MAX_VALUE);
+            fail("Where's the exception?");
+        }catch( OutOfMemoryError ex ){
+            assertTrue(ex.getMessage().contains(String.valueOf(Integer.MAX_VALUE)));
+        }
+    }
+
 }

--- a/src/test/java/jssc/SerialNativeInterfaceTest.java
+++ b/src/test/java/jssc/SerialNativeInterfaceTest.java
@@ -99,7 +99,7 @@ public class SerialNativeInterfaceTest extends DisplayMethodNameRule {
     }
 
     @Test
-    public void throwsIaeIfCountNegative() throws Exception {
+    public void throwsIfCountNegative() throws Exception {
         SerialNativeInterface testTarget = new SerialNativeInterface();
         byte[] ret;
         try{
@@ -107,6 +107,18 @@ public class SerialNativeInterfaceTest extends DisplayMethodNameRule {
             fail("Where's the exception?");
         }catch( IllegalArgumentException ex ){
             assertTrue(ex.getMessage().contains("-42"));
+        }
+    }
+
+    @Test
+    public void throwsIfCountZero() throws Exception {
+        SerialNativeInterface testTarget = new SerialNativeInterface();
+        byte[] ret;
+        try{
+            ret = testTarget.readBytes(0, 0);
+            fail("Where's the exception?");
+        }catch( IllegalArgumentException ex ){
+            assertTrue(ex.getMessage().contains("0"));
         }
     }
 

--- a/src/test/java/jssc/SerialNativeInterfaceTest.java
+++ b/src/test/java/jssc/SerialNativeInterfaceTest.java
@@ -4,6 +4,7 @@ import jssc.junit.rules.DisplayMethodNameRule;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -13,8 +14,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
+import static org.slf4j.LoggerFactory.getLogger;;
 
 public class SerialNativeInterfaceTest extends DisplayMethodNameRule {
+
+    private static final Logger log = getLogger(SerialNativeInterfaceTest.class);
 
     @Test
     public void testInitNativeInterface() {
@@ -114,13 +118,15 @@ public class SerialNativeInterfaceTest extends DisplayMethodNameRule {
         +" test run will just happily wait infinitely for those 2GiB to arrive"
         +" at the stdin fd. Feel free to remove this test if you think it"
         +" doesn't make sense to have it here.")
-    public void throwsOOMExIfRequestTooLarge() throws Exception {
+    public void throwsIfRequestTooLarge() throws Exception {
         SerialNativeInterface testTarget = new SerialNativeInterface();
+        int tooLargeSize = Integer.MAX_VALUE;
         try{
-            byte[] ret = testTarget.readBytes(0, Integer.MAX_VALUE);
+            byte[] ret = testTarget.readBytes(0, tooLargeSize);
             fail("Where's the exception?");
-        }catch( OutOfMemoryError ex ){
-            assertTrue(ex.getMessage().contains(String.valueOf(Integer.MAX_VALUE)));
+        }catch( RuntimeException ex ){
+            log.debug("Thrown, as expected :)", ex);
+            assertTrue(ex.getMessage().contains(String.valueOf(tooLargeSize)));
         }
     }
 

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,7 +1,7 @@
 # Logging settings for unit tests
 
 # The root logger with appender name
-rootLogger=DEBUG,STDOUT,TESTNAME
+rootLogger=INFO,STDOUT,TESTNAME
 
 # Assign STDOUT a valid appender & define its layout
 appender.console.name=STDOUT
@@ -20,3 +20,7 @@ appender.console.filter.1.type=MarkerFilter
 appender.console.filter.1.marker=MethodName
 appender.console.filter.1.onMatch=DENY
 appender.console.filter.1.onMismatch=ACCEPT
+
+# Configures log-level of 'jssc' java package (Handy for debugging tests).
+#logger.jssc.name = jssc
+#logger.jssc.level = DEBUG


### PR DESCRIPTION
The 2nd error covered here potentially could explain cases like https://github.com/java-native/jssc/issues/122 or related. Example: Passed-in 'byteCount' is either far too large or even a negative value which could trigger undesired behavior when used to allocate an array.