### PR TITLE
Update cross compile job

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -117,7 +117,7 @@ jobs:
                 --env MAVEN_OPTS=${MAVEN_OPTS} \
                 ${{ matrix.image }} \
                 bash -c \
-                  'apt-get update && apt-get install --yes maven openjdk-11-jdk-headless && \
+                  'apt-get update && apt-get install --yes maven openjdk-17-jdk-headless && \
                    mvn -B clean install -P dockcross,update-resources-precompiled \
                     -Dos.target.name=${{ matrix.os_target_name }} \
                     -Dos.target.arch=${{ matrix.os_target_arch }} \

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -134,7 +134,7 @@ jobs:
           while  git pull --rebase && ! git push; do sleep 5; done
 
   macos:
-    runs-on: macos-11
+    runs-on: macos-latest
     needs: create-branch
     strategy:
       matrix:
@@ -163,12 +163,12 @@ jobs:
         if: ${{ matrix.sdk-version == 'MacOSX10.9.sdk' }}
         run: |
           wget -qO- https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz \
-            | tar -xjv -C $XCODE_12_DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs
+            | tar -xjv -C $XCODE_16_DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs
 
       - name: Set SDK version
         run: |
           export MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-deployment-target }}
-          export SDKROOT=$XCODE_12_DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/${{ matrix.sdk-version }}
+          export SDKROOT=$XCODE_16_DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/${{ matrix.sdk-version }}
           export CMAKE_OSX_SYSROOT=$SDKROOT
       - name: Build with Maven
         run: mvn -B clean install -P ${{ matrix.profile }},update-resources-precompiled


### PR DESCRIPTION
Cross compilation Github action got obsoleted again:
- The Dockcross images were rebased to Debian Bookworkm, whose default repositories no longer offer `openjdk-11-jdk`. As the cross compilation does not really care about the class level, it does not hurt us to update to openjdk-17-jdk.
- The `macos-11` runner type got obsoleted, the oldest now being `macos-latest`, aka `macos-14`.