### PR TITLE
Remove Some Port Exceptions

### DIFF
--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1152,7 +1152,7 @@ public class SerialPort {
      * 
      * @throws SerialPortException if exception occurred
      */
-    private synchronized boolean removeEventListener() throws SerialPortException {
+    public synchronized boolean removeEventListener() throws SerialPortException {
         if(eventThread == null || !eventThread.isAlive()){
             return false;
         }

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1157,7 +1157,9 @@ public class SerialPort {
             return false;
         }
         eventThread.terminateThread();
-        setEventsMask(0);
+        if (portOpened) {
+            setEventsMask(0);
+        }
         //Guard against currentThread().join deadlock
         if(Thread.currentThread().getId() != eventThread.getId()){
             try {
@@ -1182,17 +1184,20 @@ public class SerialPort {
      * @throws SerialPortException if exception occurred
      */
     public synchronized boolean closePort() throws SerialPortException {
-        if (!portOpened) return false;
         boolean returnValue;
         //removeEventListener calls setEventsMask, and must occur before calling closePort
         try {
             removeEventListener();
         }
         finally {
-            returnValue = serialInterface.closePort(portHandle);
-            if (returnValue) {
-                maskAssigned = false;
-                portOpened = false;
+            if (portOpened) {
+                returnValue = serialInterface.closePort(portHandle);
+                if (returnValue) {
+                    maskAssigned = false;
+                    portOpened = false;
+                }
+            } else {
+                returnValue = false;
             }
         }
         return returnValue;

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1062,9 +1062,9 @@ public class SerialPort {
      *
      * @throws SerialPortException if exception occurred
      */
-//    public void addEventListener(SerialPortEventListener listener) throws SerialPortException {
-//        addEventListener(listener, MASK_RXCHAR, false);
-//    }
+    public void addEventListener(SerialPortEventListener listener) throws SerialPortException {
+        addEventListener(listener, MASK_RXCHAR, false);
+    }
 
     /**
      * Add event listener. Object of <b>"SerialPortEventListener"</b> type shall be sent
@@ -1079,9 +1079,9 @@ public class SerialPort {
      *
      * @throws SerialPortException if exception occurred
      */
-//    public void addEventListener(SerialPortEventListener listener, int mask) throws SerialPortException {
-//        addEventListener(listener, mask, true);
-//    }
+    public void addEventListener(SerialPortEventListener listener, int mask) throws SerialPortException {
+        addEventListener(listener, mask, true);
+    }
 
     /**
      * Internal method. Add event listener. Object of <b>"SerialPortEventListener"</b> type shall be sent

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1152,7 +1152,7 @@ public class SerialPort {
      * 
      * @throws SerialPortException if exception occurred
      */
-    public synchronized boolean removeEventListener() throws SerialPortException {
+    private synchronized boolean removeEventListener() throws SerialPortException {
         if(eventThread == null || !eventThread.isAlive()){
             return false;
         }

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1182,18 +1182,19 @@ public class SerialPort {
      * @throws SerialPortException if exception occurred
      */
     public synchronized boolean closePort() throws SerialPortException {
+        boolean returnValue;
         //removeEventListener calls setEventsMask, and must occur before calling closePort
         try {
             removeEventListener();
         }
         finally {
-            boolean returnValue = serialInterface.closePort(portHandle);
+            returnValue = serialInterface.closePort(portHandle);
             if (returnValue) {
                 maskAssigned = false;
                 portOpened = false;
             }
-            return returnValue;
         }
+        return returnValue;
     }
 
     private EventThread eventThread;

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1155,11 +1155,10 @@ public class SerialPort {
      * @throws SerialPortException if exception occurred
      */
     public synchronized boolean removeEventListener() throws SerialPortException {
-        checkPortOpened("removeEventListener()");
-        if(!eventListenerAdded){
-            throw new SerialPortException(this, "removeEventListener()", SerialPortException.TYPE_CANT_REMOVE_LISTENER);
-        }
         eventThread.terminateThread();
+        if(!eventListenerAdded){
+            return false;
+        }
         setEventsMask(0);
         if(Thread.currentThread().getId() != eventThread.getId()){
             if(eventThread.isAlive()){
@@ -1184,7 +1183,6 @@ public class SerialPort {
      * @throws SerialPortException if exception occurred
      */
     public synchronized boolean closePort() throws SerialPortException {
-        checkPortOpened("closePort()");
         if(eventListenerAdded){
             removeEventListener();
         }

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1160,14 +1160,14 @@ public class SerialPort {
             return false;
         }
         setEventsMask(0);
+        //Guard against currentThread().join deadlock
         if(Thread.currentThread().getId() != eventThread.getId()){
-            if(eventThread.isAlive()){
-                try {
-                    eventThread.join(5000);
-                }
-                catch (InterruptedException ex) {
-                    throw new SerialPortException(this, "removeEventListener()", SerialPortException.TYPE_LISTENER_THREAD_INTERRUPTED);
-                }
+            try {
+                Thread.currentThread().join(6);
+                eventThread.join(5000);
+            }
+            catch (InterruptedException ex) {
+                throw new SerialPortException(this, "removeEventListener()", SerialPortException.TYPE_LISTENER_THREAD_INTERRUPTED);
             }
         }
         methodErrorOccurred = null;

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1182,6 +1182,7 @@ public class SerialPort {
      * @throws SerialPortException if exception occurred
      */
     public synchronized boolean closePort() throws SerialPortException {
+        if (!portOpened) return false;
         boolean returnValue;
         //removeEventListener calls setEventsMask, and must occur before calling closePort
         try {

--- a/src/main/java/jssc/SerialPort.java
+++ b/src/main/java/jssc/SerialPort.java
@@ -1101,7 +1101,7 @@ public class SerialPort {
      *
      * @throws SerialPortException if exception occurred
      */
-    public synchronized void addEventListener(SerialPortEventListener listener, int mask, boolean overwriteMask) throws SerialPortException {
+    private synchronized void addEventListener(SerialPortEventListener listener, int mask, boolean overwriteMask) throws SerialPortException {
         checkPortOpened("addEventListener()");
         if(eventThread == null || !eventThread.isAlive()){
             if((maskAssigned && overwriteMask) || !maskAssigned) {

--- a/src/main/java/jssc/SerialPortException.java
+++ b/src/main/java/jssc/SerialPortException.java
@@ -41,7 +41,7 @@ public class SerialPortException extends Exception {
     /** Event listener thread interrupted **/
     final public static String TYPE_LISTENER_THREAD_INTERRUPTED = "Event listener thread interrupted";
     /** Can't remove event listener **/
-    final public static String TYPE_CANT_REMOVE_LISTENER = "Can't remove event listener, because listener not added";
+    final public static String TYPE_CANT_REMOVE_LISTENER = "Can't remove event listener";
     /**
      * @since 0.8
      */


### PR DESCRIPTION
Removed port exceptions from `closePort` and `closePort`. This brings their behavior in line with the existing documentation.

Fixes https://github.com/java-native/jssc/issues/107