### PR TITLE
Functionality to allow set exotic ports names on Linux and MacOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+
   <groupId>io.github.java-native</groupId>
   <artifactId>jssc</artifactId>
   <version>2.9.7-SNAPSHOT</version>
@@ -55,6 +56,7 @@
     <dependency.log4j.version>2.22.0</dependency.log4j.version>
     <dependency.logback.version>1.2.3</dependency.logback.version>
     <dependency.nativelibloader.version>2.5.0</dependency.nativelibloader.version>
+    <dependency.mockito.version>4.11.0</dependency.mockito.version>
 
     <!-- plugin versions a-z -->
     <plugin.animalsniffer.version>1.17</plugin.animalsniffer.version>
@@ -73,7 +75,7 @@
     <plugin.signature.version>1.1</plugin.signature.version>
     <plugin.source.version>3.0.1</plugin.source.version>
     <plugin.surfire.version>3.0.0-M4</plugin.surfire.version>
-    <update-resources-precompiled.skip>true</update-resources-precompiled.skip>
+   <update-resources-precompiled.skip>true</update-resources-precompiled.skip>
   </properties>
 
   <dependencies>
@@ -98,6 +100,18 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${dependency.junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${dependency.mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${dependency.mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <plugin.signature.version>1.1</plugin.signature.version>
     <plugin.source.version>3.0.1</plugin.source.version>
     <plugin.surfire.version>3.0.0-M4</plugin.surfire.version>
-   <update-resources-precompiled.skip>true</update-resources-precompiled.skip>
+    <update-resources-precompiled.skip>true</update-resources-precompiled.skip>
   </properties>
 
   <dependencies>

--- a/src/main/java/jssc/SerialNativeInterface.java
+++ b/src/main/java/jssc/SerialNativeInterface.java
@@ -100,6 +100,25 @@ public class SerialNativeInterface {
      */
     public static final String PROPERTY_JSSC_PARMRK = "JSSC_PARMRK";
 
+    /**
+     * Allow set exotic port name(s)
+     *
+     * Usage:
+     * <code>System.setProperty("JSSC_ALLOW_EXOTIC_NAMES", "true");</code>
+     *
+     * @since 2.9.7
+     */
+    public static final String PROPERTY_JSSC_ALLOW_EXOTIC_NAMES = "JSSC_ALLOW_EXOTIC_NAMES";
+    /**
+     * Exotic port name(s)
+     *
+     * Usage:
+     * <code>System.setProperty("JSSC_EXOTIC_NAMES", "ttyU,com");</code>
+     *
+     * @since 2.9.7
+     */
+    public static final String PROPERTY_JSSC_EXOTIC_NAMES = "JSSC_EXOTIC_NAMES";
+
     private static int osType;
     static {
         String osName = System.getProperty("os.name");

--- a/src/main/java/jssc/SerialPortList.java
+++ b/src/main/java/jssc/SerialPortList.java
@@ -49,7 +49,7 @@ public class SerialPortList {
         serialInterface = new SerialNativeInterface();
         switch (SerialNativeInterface.getOsType()) {
             case SerialNativeInterface.OS_LINUX: {
-                PORTNAMES_REGEXP = Pattern.compile("(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO)[0-9]{1,3}");
+                PORTNAMES_REGEXP = Pattern.compile("(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO|ttyM|ttyMXUSB|ttyMUE)[0-9]{1,3}");
                 PORTNAMES_PATH = "/dev/";
                 break;
             }

--- a/src/test/java/jssc/SerialPortListTest.java
+++ b/src/test/java/jssc/SerialPortListTest.java
@@ -1,0 +1,95 @@
+package jssc;
+
+import jssc.junit.rules.DisplayMethodNameRule;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+
+public class SerialPortListTest extends DisplayMethodNameRule {
+
+    private static final String BASIC_LINUX_PORTNAME_REGEXP = "(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO|ttyM|ttyMXUSB|ttyMUE%s)[0-9]{1,3}";
+    private static final String BASIC_MAC_OS_PORTNAME_REGEXP = "(tty|cu%s)\\..*";
+
+    private void prepareEnv() {
+        System.clearProperty(SerialNativeInterface.PROPERTY_JSSC_ALLOW_EXOTIC_NAMES);
+        System.clearProperty(SerialNativeInterface.PROPERTY_JSSC_EXOTIC_NAMES);
+    }
+
+    @Test
+    public void checkSerialPortNameRegExpOnLinux() {
+        MockedStatic<SerialNativeInterface> serialNativeInterface = null;
+        prepareEnv();
+
+        try {
+            serialNativeInterface = Mockito.mockStatic(SerialNativeInterface.class);
+            serialNativeInterface.when(SerialNativeInterface::getOsType).thenReturn(SerialNativeInterface.OS_LINUX);
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_LINUX_PORTNAME_REGEXP, ""), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_EXOTIC_NAMES, "abc");
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_LINUX_PORTNAME_REGEXP, ""), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_ALLOW_EXOTIC_NAMES, "true");
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_LINUX_PORTNAME_REGEXP, "|abc"), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_ALLOW_EXOTIC_NAMES, "false");
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_LINUX_PORTNAME_REGEXP, ""), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_ALLOW_EXOTIC_NAMES, "true");
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_EXOTIC_NAMES, "abc1d|bvc");
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_LINUX_PORTNAME_REGEXP, "|abc|d|bvc"), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.clearProperty(SerialNativeInterface.PROPERTY_JSSC_EXOTIC_NAMES);
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_LINUX_PORTNAME_REGEXP, ""), SerialPortList.getPortnamesRegexp().pattern());
+        } finally {
+            if(serialNativeInterface != null) {
+                serialNativeInterface.close();
+            }
+        }
+    }
+
+    @Test
+    public void checkSerialPortNameRegExpOnMacOS() {
+        MockedStatic<SerialNativeInterface> serialNativeInterface = null;
+        prepareEnv();
+
+        try {
+            serialNativeInterface = Mockito.mockStatic(SerialNativeInterface.class);
+            serialNativeInterface.when(SerialNativeInterface::getOsType).thenReturn(SerialNativeInterface.OS_MAC_OS_X);
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_MAC_OS_PORTNAME_REGEXP, ""), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_EXOTIC_NAMES, "abc");
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_MAC_OS_PORTNAME_REGEXP, ""), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_ALLOW_EXOTIC_NAMES, "true");
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_MAC_OS_PORTNAME_REGEXP, "|abc"), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_ALLOW_EXOTIC_NAMES, "false");
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_MAC_OS_PORTNAME_REGEXP, ""), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_ALLOW_EXOTIC_NAMES, "true");
+            System.setProperty(SerialNativeInterface.PROPERTY_JSSC_EXOTIC_NAMES, "abc1d|bvc");
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_MAC_OS_PORTNAME_REGEXP, "|abc|d|bvc"), SerialPortList.getPortnamesRegexp().pattern());
+
+            System.clearProperty(SerialNativeInterface.PROPERTY_JSSC_EXOTIC_NAMES);
+            SerialPortList.initSearchParameters();
+            Assert.assertEquals(String.format(BASIC_MAC_OS_PORTNAME_REGEXP, ""), SerialPortList.getPortnamesRegexp().pattern());
+        } finally {
+            if(serialNativeInterface != null) {
+                serialNativeInterface.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added functionality for providing exotic port's names on Linux and MacOS as was asked in (https://github.com/java-native/jssc/issues/179#issuecomment-2561616045) and tests for this new functionality as was asked in (https://github.com/java-native/jssc/issues/179#issuecomment-2564389165)